### PR TITLE
빌드 시, QuestLog의 QuestItem(root)의 image가 Objective들의 길이에 맞게 늘어나지 않는 문제

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/UI/Views/QuestItemView.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/UI/Views/QuestItemView.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.UI;
 using TMPro;
 using System.Collections.Generic;
 
@@ -49,6 +50,8 @@ public class QuestItemView : MonoBehaviour
                 }
             }
         }
+
+        LayoutRebuilder.ForceRebuildLayoutImmediate(transform as RectTransform);
     }
 
     private void AddObjective(QuestObjective objective, bool visible)
@@ -76,5 +79,7 @@ public class QuestItemView : MonoBehaviour
             if (objectiveViews.TryGetValue(nextId, out var nextView))
                 nextView.SetVisible(true);
         }
+
+        LayoutRebuilder.ForceRebuildLayoutImmediate(transform as RectTransform);
     }
 }


### PR DESCRIPTION
요약: 크기를 처리하는 순서/타이밍? 때문이라고 함. 간단하게 해결

클로드의 한마디: QuestItemView.Initialize()에서 Instantiate → SetVisible(false) → SetVisible(true) 순서로 호출하는데, SetVisible은 gameObject.SetActive()를 사용합니다. 빌드에서는 SetActive(false)로 비활성화된 오브젝트가 ContentSizeFitter / LayoutGroup 계산에서 제외되며, 나중에 SetActive(true)로 켜도 그 프레임에 레이아웃이 재계산되지 않습니다. 에디터에서는 Inspector가 매 프레임 강제 갱신을 유발하므로 동작하는 것처럼 보입니다.

QuestItemView.Initialize() 끝에 ForceRebuildLayoutImmediate를 추가하면 됩니다.

