### PR TITLE
Feat/skip intro

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Resources/Data/Dialogues/Yarn/DLG_INTRO.yarn
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Resources/Data/Dialogues/Yarn/DLG_INTRO.yarn
@@ -38,6 +38,16 @@ tags: phase:INTRO
 주인공: 어... 어라? 내 거대 골렘은 어디 가고 왜 이렇게 쪼끄만 애가... 설마 보석이 잘못됐나?
 골렘: 히히, 여기는 신기하네요! 저기... 당신의 이름은 뭔가요? 제일 먼저 알고 싶어요!
 
+<<jump DLG_INTRO_NAMES>>
+===
+
+title: DLG_INTRO_NAMES
+tags: phase:INTRO
+---
+// === 이름 입력 구간 — skip 버튼 비활성 ===
+<<show_image 4>>
+<<hide_skip>>
+
 // === 플레이어 이름 입력 ===
 <<request_name_input>>
 
@@ -46,6 +56,9 @@ tags: phase:INTRO
 
 // === 골렘 이름 입력 ===
 <<request_golem_name_input>>
+
+// === 이름 입력 완료 — 이후부터 skip 가능 ===
+<<show_skip>>
 
 주인공: 너는 이제부터 {$golemName}이야.
 골렘: {$golemName}! 우와아, 정말 마음에 쏙 들어요!

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Intro.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Intro.unity
@@ -119,6 +119,127 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &27033121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 27033122}
+  - component: {fileID: 27033125}
+  - component: {fileID: 27033124}
+  - component: {fileID: 27033123}
+  m_Layer: 5
+  m_Name: Skip Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &27033122
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 27033121}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 995137431}
+  m_Father: {fileID: 733257507}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -210, y: 250}
+  m_SizeDelta: {x: 98, y: 55}
+  m_Pivot: {x: 1, y: 0}
+--- !u!114 &27033123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 27033121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.61635214, g: 0.61635214, b: 0.61635214, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 27033124}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &27033124
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 27033121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c9e2cf5d8b23c45c9bd1489b2f1d1c16, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &27033125
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 27033121}
+  m_CullTransparentMesh: 1
 --- !u!1 &79831987
 GameObject:
   m_ObjectHideFlags: 0
@@ -1235,6 +1356,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 1148601900808237763, guid: 61ae7ce6ad90a13408ca5b686a480e03, type: 3}
       insertIndex: 3
       addedObject: {fileID: 1492721656}
+    - targetCorrespondingSourceObject: {fileID: 1148601900808237763, guid: 61ae7ce6ad90a13408ca5b686a480e03, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 27033122}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 61ae7ce6ad90a13408ca5b686a480e03, type: 3}
 --- !u!224 &733257507 stripped
@@ -1978,6 +2102,142 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 951318778}
+  m_CullTransparentMesh: 1
+--- !u!1 &995137430
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 995137431}
+  - component: {fileID: 995137433}
+  - component: {fileID: 995137432}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &995137431
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 995137430}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 27033122}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -115, y: 5}
+  m_SizeDelta: {x: 230, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &995137432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 995137430}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uB118\uAE30\uAE30"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 3f5c05ef14383452c99a018a291744a7, type: 2}
+  m_sharedMaterial: {fileID: -6193203460992081240, guid: 3f5c05ef14383452c99a018a291744a7, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &995137433
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 995137430}
   m_CullTransparentMesh: 1
 --- !u!1 &997664412
 GameObject:
@@ -3629,6 +3889,10 @@ MonoBehaviour:
   onboardingPanel: {fileID: 1897671712}
   keyGuidePanel: {fileID: 2138385542}
   dialoguePanelCanvasGroup: {fileID: 733257511}
+  skipButton: {fileID: 27033123}
+  imagePresenter: {fileID: 905290449}
+  nameInputPresenter: {fileID: 2106584422}
+  golemNameInputPresenter: {fileID: 1492721657}
 --- !u!1 &1518588230
 GameObject:
   m_ObjectHideFlags: 0

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Core/Debug/DebugConsoleController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Core/Debug/DebugConsoleController.cs
@@ -76,5 +76,12 @@ public class DebugConsoleController : MonoBehaviour
         Debug.Log($"[scene.load] {sceneName} 로드 중...");
         SceneManager.LoadScene(sceneName);
     }
+
+    [ConsoleMethod("data.reset", "플레이어 데이터 및 인트로 시청 기록을 초기화한다.")]
+    public static void Cmd_ResetData()
+    {
+        GameManager.Instance.ResetAllData();
+        Debug.Log("[data.reset] 완료. 인트로 시청 기록 포함 playerpref 데이터 초기화됨.");
+    }
 #endif
 }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Core/Managers/GameManager.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Core/Managers/GameManager.cs
@@ -103,6 +103,7 @@ public class GameManager : MonoBehaviour
     {
         _data = new PlayerData();
         PlayerPrefs.DeleteKey(SaveKey);
+        PlayerPrefs.DeleteKey("Intro_Watched");
         PlayerPrefs.Save();
         Debug.Log("[GameManager] All player data reset.");
     }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Intro/IntroImagePresenter.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Intro/IntroImagePresenter.cs
@@ -42,7 +42,13 @@ public class IntroImagePresenter : MonoBehaviour
             yield break;
         }
 
-        // 이미 표시 중이면 빠르게 페이드아웃 후 교체
+        // 이미 같은 이미지가 완전히 표시 중이면 불필요한 fade 없이 종료
+        if (imagePanel.gameObject.activeSelf
+            && imagePanel.alpha >= 1f
+            && displayImage.sprite == cardSprites[index])
+            yield break;
+
+        // 다른 이미지가 표시 중이면 페이드아웃 후 교체
         if (imagePanel.gameObject.activeSelf && imagePanel.alpha > 0f)
         {
             yield return FadeTo(0f);
@@ -58,6 +64,14 @@ public class IntroImagePresenter : MonoBehaviour
     private IEnumerator HideImage()
     {
         yield return FadeTo(0f);
+        imagePanel.gameObject.SetActive(false);
+    }
+
+    public void ForceHide()
+    {
+        if (_fadeCoroutine != null)
+            StopCoroutine(_fadeCoroutine);
+        imagePanel.alpha = 0f;
         imagePanel.gameObject.SetActive(false);
     }
 

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Intro/IntroSceneController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Intro/IntroSceneController.cs
@@ -1,5 +1,7 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.UI;
 using Yarn.Unity;
 
 /// <summary>
@@ -8,10 +10,16 @@ using Yarn.Unity;
 /// 흐름:
 ///   [패널 1] 온보딩 (조명/카메라·음성 안내) → 아무 키 dismiss
 ///   → [패널 2] 키 가이드 (WASD·E 설명) → 아무 키 dismiss
-///   → DLG_INTRO 다이얼로그 실행
-///   → nextSceneName 씬 전환
+///   → DLG_INTRO 다이얼로그 실행 (내러티브)
+///   → <<jump DLG_INTRO_NAMES>> (이름 입력 구간, skip 버튼 비활성)
+///   → 이름 입력 완료 후 <<show_skip>> → skip 가능
+///   → nextSceneName 씬 전환 및 Intro_Watched 저장
 ///
-/// 두 패널 모두 Inspector에서 연결하지 않으면 해당 단계를 건너뛰고 다음으로 진행한다.
+/// Skip 버튼:
+///   - 대화 시작(StartIntroDialogue) 시점에 활성화
+///   - Yarn <<hide_skip>> / <<show_skip>> 커맨드로 가시성 제어
+///   - 이름 미입력 상태에서 skip → DLG_INTRO_NAMES 노드로 점프
+///   - 이름 입력 완료 후 skip → 즉시 씬 전환 + Intro_Watched 저장
 /// </summary>
 public class IntroSceneController : MonoBehaviour
 {
@@ -25,12 +33,18 @@ public class IntroSceneController : MonoBehaviour
     [Header("온보딩 패널 (인트로 시작 전 — 조명/카메라·음성 안내)")]
     [SerializeField] private DismissablePanelController onboardingPanel;
 
-    [Header("키 가이드 패널 (인트로 대화 완료 후 — WASD·E 조작 안내)")]
+    [Header("키 가이드 패널 (온보딩 이후 — WASD·E 조작 안내)")]
     [SerializeField] private DismissablePanelController keyGuidePanel;
 
     [Header("대화 UI — 온보딩 중 숨김 처리 (SetActive 금지 → alpha 사용)")]
     [Tooltip("DialogueCanvas 안의 DialoguePanel CanvasGroup. 온보딩 중 alpha=0으로 숨긴다.")]
     [SerializeField] private CanvasGroup dialoguePanelCanvasGroup;
+
+    [Header("스킵 — Yarn <<hide_skip>> / <<show_skip>>으로 가시성 제어")]
+    [SerializeField] private Button skipButton;
+    [SerializeField] private IntroImagePresenter imagePresenter;
+    [SerializeField] private NameInputPresenter nameInputPresenter;
+    [SerializeField] private GolemNameInputPresenter golemNameInputPresenter;
 
     private void Start()
     {
@@ -49,6 +63,23 @@ public class IntroSceneController : MonoBehaviour
 
         Debug.Log($"[IntroSceneController] IsDialogueRunning: {dialogueRunner.IsDialogueRunning}");
         dialogueRunner.onDialogueComplete.AddListener(OnDialogueComplete);
+
+        // Yarn 커맨드로 skip 버튼 가시성 제어
+        dialogueRunner.AddCommandHandler("hide_skip", () =>
+        {
+            if (skipButton != null) skipButton.gameObject.SetActive(false);
+        });
+        dialogueRunner.AddCommandHandler("show_skip", () =>
+        {
+            if (skipButton != null) skipButton.gameObject.SetActive(true);
+        });
+
+        // Skip 버튼은 대화 시작(StartIntroDialogue) 전까지 비활성
+        if (skipButton != null)
+        {
+            skipButton.gameObject.SetActive(false);
+            skipButton.onClick.AddListener(OnSkipClicked);
+        }
 
         // 온보딩 패널이 연결되어 있으면 먼저 표시, 없으면 바로 대화 시작
         if (onboardingPanel != null)
@@ -76,10 +107,63 @@ public class IntroSceneController : MonoBehaviour
             dialogueRunner.onDialogueComplete.RemoveListener(OnDialogueComplete);
         if (onboardingPanel != null)
             onboardingPanel.OnDismissed -= OnOnboardingDismissed;
+        if (keyGuidePanel != null)
+            keyGuidePanel.OnDismissed -= OnKeyGuideDismissed;
+        if (skipButton != null)
+            skipButton.onClick.RemoveListener(OnSkipClicked);
     }
 
     // ──────────────────────────────────────────────────────────────
-    // 온보딩 패널 → 대화
+    // 스킵
+    // ──────────────────────────────────────────────────────────────
+
+    private void OnSkipClicked()
+    {
+        if (skipButton != null)
+            skipButton.gameObject.SetActive(false);
+
+        // 안전망: 이름 입력 패널이 열려 있으면 닫기 (정상적으로는 <<hide_skip>>으로 방지됨)
+        nameInputPresenter?.ForceCancel();
+        golemNameInputPresenter?.ForceCancel();
+
+        imagePresenter?.ForceHide();
+
+        if (dialogueRunner != null && dialogueRunner.IsDialogueRunning)
+        {
+            dialogueRunner.onDialogueComplete.RemoveListener(OnDialogueComplete);
+            dialogueRunner.Stop();
+        }
+
+        // 이름 미입력 → 이름 입력 노드로 점프해서 Yarn 대화 재개
+        // 이름 완료  → Intro_Watched 저장 후 즉시 씬 전환
+        if (!GameManager.Instance.HasPlayerName || !GameManager.Instance.HasGolemName)
+            StartCoroutine(JumpToNode("DLG_INTRO_NAMES"));
+        else
+        {
+            PlayerPrefs.SetInt(PrefKeyIntroWatched, 1);
+            PlayerPrefs.Save();
+            LoadNextScene();
+        }
+    }
+
+    private IEnumerator JumpToNode(string nodeName)
+    {
+        yield return null; // Stop() 정리 후 한 프레임 대기
+
+        // 대화 UI 복원 (온보딩 중 skip된 경우 alpha=0일 수 있음)
+        if (dialoguePanelCanvasGroup != null)
+        {
+            dialoguePanelCanvasGroup.alpha = 1f;
+            dialoguePanelCanvasGroup.interactable = true;
+            dialoguePanelCanvasGroup.blocksRaycasts = true;
+        }
+
+        dialogueRunner.onDialogueComplete.AddListener(OnDialogueComplete);
+        dialogueRunner.StartDialogue(nodeName);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 온보딩 패널 → 키 가이드 패널 → 대화
     // ──────────────────────────────────────────────────────────────
 
     private void OnOnboardingDismissed()
@@ -106,7 +190,7 @@ public class IntroSceneController : MonoBehaviour
 
     private void StartIntroDialogue()
     {
-        // 대화 UI 다시 표시 (LinePresenter가 fade-in 처리)
+        // 대화 UI 표시 (온보딩 중 숨겼던 것 복원)
         if (dialoguePanelCanvasGroup != null)
         {
             dialoguePanelCanvasGroup.alpha = 1f;
@@ -114,16 +198,25 @@ public class IntroSceneController : MonoBehaviour
             dialoguePanelCanvasGroup.blocksRaycasts = true;
         }
 
+        // 대화 시작 시 skip 버튼 활성화
+        if (skipButton != null)
+            skipButton.gameObject.SetActive(true);
+
         dialogueRunner.StartDialogue("DLG_INTRO");
         Debug.Log($"[IntroSceneController] StartDialogue 호출 후 IsDialogueRunning: {dialogueRunner.IsDialogueRunning}");
     }
 
     // ──────────────────────────────────────────────────────────────
-    // 대화 완료 → 키 가이드 패널 → 씬 전환
+    // 대화 완료 → Intro_Watched 저장 → 씬 전환
     // ──────────────────────────────────────────────────────────────
 
     private void OnDialogueComplete()
     {
+        // 이름이 모두 입력된 경우에만 인트로 완료 처리
+        // (씬 언로드/앱 종료 시 DialogueRunner가 이벤트를 발생시키는 것에 대한 방어)
+        if (!GameManager.Instance.HasPlayerName || !GameManager.Instance.HasGolemName)
+            return;
+
         PlayerPrefs.SetInt(PrefKeyIntroWatched, 1);
         PlayerPrefs.Save();
         LoadNextScene();

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Intro/IntroSceneController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Intro/IntroSceneController.cs
@@ -15,6 +15,10 @@ using Yarn.Unity;
 /// </summary>
 public class IntroSceneController : MonoBehaviour
 {
+    private const string PrefKeyIntroWatched = "Intro_Watched";
+
+    public static bool HasWatched => PlayerPrefs.GetInt(PrefKeyIntroWatched, 0) == 1;
+
     [SerializeField] private DialogueRunner dialogueRunner;
     [SerializeField] private string nextSceneName = "World";
 
@@ -120,6 +124,8 @@ public class IntroSceneController : MonoBehaviour
 
     private void OnDialogueComplete()
     {
+        PlayerPrefs.SetInt(PrefKeyIntroWatched, 1);
+        PlayerPrefs.Save();
         LoadNextScene();
     }
 

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/MainMenu/MainMenuController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/MainMenu/MainMenuController.cs
@@ -37,7 +37,10 @@ public class MainMenuController : MonoBehaviour
 
     private void LoadStartScene()
     {
-        SceneManager.LoadScene(IntroSceneController.HasWatched ? postIntroSceneName : introSceneName);
+        bool introComplete = IntroSceneController.HasWatched
+            && GameManager.Instance.HasPlayerName
+            && GameManager.Instance.HasGolemName;
+        SceneManager.LoadScene(introComplete ? postIntroSceneName : introSceneName);
     }
 
     public void OnSettings()

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/MainMenu/MainMenuController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/MainMenu/MainMenuController.cs
@@ -4,6 +4,7 @@ using UnityEngine.SceneManagement;
 public class MainMenuController : MonoBehaviour
 {
     [SerializeField] private string introSceneName = "Intro";
+    [SerializeField] private string postIntroSceneName = "Forest";
     [SerializeField] private SettingsPresenter settingsPresenter;
     [SerializeField] private PrivacyConsentPresenter privacyConsentPresenter;
 
@@ -31,7 +32,12 @@ public class MainMenuController : MonoBehaviour
             return;
         }
 
-        SceneManager.LoadScene(introSceneName);
+        LoadStartScene();
+    }
+
+    private void LoadStartScene()
+    {
+        SceneManager.LoadScene(IntroSceneController.HasWatched ? postIntroSceneName : introSceneName);
     }
 
     public void OnSettings()
@@ -60,7 +66,7 @@ public class MainMenuController : MonoBehaviour
         if (_pendingStart)
         {
             _pendingStart = false;
-            SceneManager.LoadScene(introSceneName);
+            LoadStartScene();
         }
     }
 }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/UI/Presenters/GolemNameInputPresenter.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/UI/Presenters/GolemNameInputPresenter.cs
@@ -37,6 +37,13 @@ public class GolemNameInputPresenter : MonoBehaviour
         panel.SetActive(false);
     }
 
+    public void ForceCancel()
+    {
+        if (!panel.activeSelf) return;
+        panel.SetActive(false);
+        _confirmed = true; // WaitUntil 해제 (저장 없이)
+    }
+
     private void OnConfirm()
     {
         string input = nameInputField.text.Trim();

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/UI/Presenters/NameInputPresenter.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/UI/Presenters/NameInputPresenter.cs
@@ -37,6 +37,13 @@ public class NameInputPresenter : MonoBehaviour
         panel.SetActive(false);
     }
 
+    public void ForceCancel()
+    {
+        if (!panel.activeSelf) return;
+        panel.SetActive(false);
+        _confirmed = true; // WaitUntil 해제 (저장 없이)
+    }
+
     private void OnConfirm()
     {
         string input = nameInputField.text.Trim();


### PR DESCRIPTION
# 인트로 스킵 기능 추가
## 개요
인트로를 이미 완료한 플레이어가 재방문 시 불필요하게 전체 인트로를 다시 보지 않도록 스킵 기능 구현.
이름 입력 구간은 스킵 불가 처리하여 데이터 무결성 보장.

## 변경 사항
### 인트로 스킵 흐름

- 인트로 대화 시작 시 Skip 버튼 활성화, 이름 입력 구간 진입 시 자동 비활성화 (<<hide_skip>> / <<show_skip>>)
- Skip 클릭 시 이름 미입력 상태면 DLG_INTRO_NAMES 노드로 점프하여 이름 입력 진행
- 이름 입력 완료 후 Skip 클릭 시 즉시 다음 씬으로 전환
- Intro_Watched 플래그는 이름이 모두 입력된 경우에만 저장
- 이름 완료 여부를 메인 메뉴 씬 분기 조건에도 추가하여 플래그-데이터 불일치 방어

### 디버그

- `data.reset` 콘솔 커맨드 추가 — PlayerPrefs 전체 및 Intro_Watched 일괄 초기화

## 테스트 체크리스트

- [x]  인트로 미완료 상태에서 처음부터 정상 진행 → Forest 진입
- [X]  인트로 대화 중 Skip → 이름 입력 노드로 점프 → 이름 입력 후 Skip → Forest 진입
- [X]  이름 입력 완료 후 인트로 완료 → 메인 메뉴 재진입 시 Forest로 바로 진입
- [X]  이름 입력 도중 앱 종료 후 재진입 → 인트로 처음부터 재실행
- [X]  data.reset 후 메인 메뉴에서 인트로 재진입