### PR TITLE
fix/dev build

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Core/Debug/DebugConsoleController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Core/Debug/DebugConsoleController.cs
@@ -22,6 +22,9 @@ public class DebugConsoleController : MonoBehaviour
         }
         Instance = this;
         DontDestroyOnLoad(gameObject);
+#if DEVELOPMENT_BUILD
+        Debug.developerConsoleVisible = false;
+#endif
     }
 
 #if UNITY_EDITOR || DEVELOPMENT_BUILD

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Core/Input/GameInputActions.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Core/Input/GameInputActions.cs
@@ -917,7 +917,7 @@ public partial class @GameInputActions: IInputActionCollection2, IDisposable
         /// </summary>
         public InputAction @Gather => m_Wrapper.m_PlayerActions_Gather;
         /// <summary>
-        /// Provides access to the underlying input action "PlayerActions/Interact".
+        /// Provides access to the underlying input action "PlayerActions/InteractNPC".
         /// </summary>
         public InputAction @InteractNPC => m_Wrapper.m_PlayerActions_InteractNPC;
         /// <summary>
@@ -1124,6 +1124,9 @@ public partial class @GameInputActions: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "Global/ToggleQuest".
         /// </summary>
         public InputAction @ToggleQuest => m_Wrapper.m_Global_ToggleQuest;
+        /// <summary>
+        /// Provides access to the underlying input action "Global/TogglePause".
+        /// </summary>
         public InputAction @TogglePause => m_Wrapper.m_Global_TogglePause;
         /// <summary>
         /// Provides access to the underlying input action map instance.
@@ -1508,7 +1511,7 @@ public partial class @GameInputActions: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnGather(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Interact" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "InteractNPC" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
@@ -1551,6 +1554,12 @@ public partial class @GameInputActions: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnToggleQuest(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "TogglePause" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnTogglePause(InputAction.CallbackContext context);
     }
     /// <summary>

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Core/Input/GameInputActions.inputactions
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Core/Input/GameInputActions.inputactions
@@ -163,7 +163,7 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Interact",
+                    "name": "InteractNPC",
                     "type": "Button",
                     "id": "f1a2b3c4-d5e6-7f8a-9b0c-d1e2f3a4b5c6",
                     "expectedControlType": "",
@@ -191,7 +191,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Interact",
+                    "action": "InteractNPC",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }
@@ -246,6 +246,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "TogglePause",
+                    "type": "Button",
+                    "id": "b1c2d3e4-f5a6-7b8c-9d0e-f1a2b3c4d5e6",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -268,6 +277,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "ToggleQuest",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c2d3e4f5-a6b7-8c9d-0e1f-a2b3c4d5e6f7",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "TogglePause",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }


### PR DESCRIPTION
<h1>Development Build 버그 수정</h1>
<h2>개요</h2>
<p>Development build 환경에서 발생하는 두 가지 버그 수정.

- E 키 상호작용이 빌드 시 동작하지 않는 문제
- Unity 기본 개발자 콘솔이 IngameDebugConsole과 중복 표시되는 문제

<h2>변경 사항</h2>
<h3>E 키 상호작용 빌드 오류 수정</h3>
<p><strong>원인</strong>
<code>GameInputActions.inputactions</code> (소스 에셋)과 수동 편집된 <code>GameInputActions.cs</code> (생성 코드) 간 액션 이름 불일치</p>

항목 | .inputactions (수정 전) | GameInputActions.cs
-- | -- | --
PlayerActions 액션명 | Interact | InteractNPC
Global - TogglePause | 없음 | 있음 (ESC 바인딩)


<p><code>.inputactions.meta</code>에 <code>generateWrapperCode: 1</code>이 설정되어 있어 빌드 시 Unity가 에셋을 reimport하면 <code>GameInputActions.cs</code>가 재생성되어 <code>PlayerInteraction.cs</code>, <code>InputModeController.cs</code>의 컴파일이 실패. 플레이어의 키 입력 처리 못함.</p>

<p><strong>수정 내용</strong></p>
<ul>
<li><code>PlayerActions/Interact</code> → <code>InteractNPC</code> 로 이름 변경</li>
<li><code>Global</code> 맵에 <code>TogglePause</code> 액션 및 ESC 바인딩 추가</li>
</ul>
<h3>Unity 기본 개발자 콘솔 비활성화</h3>
<p><strong>원인</strong>
Development build 실행 시 Unity 내장 개발자 콘솔이 자동으로 활성화되어 IngameDebugConsole 에셋과 중복 표시</p>
<p><strong>수정 내용</strong>

<code>DebugConsoleController.Awake()</code>에서 <code>Debug.developerConsoleVisible = false</code> 호출</p>
<ul>
<li><code>#if DEVELOPMENT_BUILD</code> 조건부 컴파일로 릴리즈 빌드에는 영향 없음</li>
</ul>

