### PR TITLE
feat: 골렘 표정 시스템 — Realtime tool calling 연동

### DIFF
--- a/GoGoGolem/src/ai/.gitignore
+++ b/GoGoGolem/src/ai/.gitignore
@@ -2,4 +2,5 @@
 .venv/*
 __pycache__/
 *.json
+!interaction/speech/prompts/*.json
 tests

--- a/GoGoGolem/src/ai/interaction/core/components/realtime_components/realtime_llm_component.py
+++ b/GoGoGolem/src/ai/interaction/core/components/realtime_components/realtime_llm_component.py
@@ -52,6 +52,8 @@ class RealtimeLLMComponent:
         # GA API 이벤트 이름 변경: response.audio.* → response.output_audio.*
         RESPONSE_AUDIO_DELTA = "response.output_audio.delta"
         RESPONSE_AUDIO_DONE = "response.output_audio.done"
+        RESPONSE_FUNCTION_CALL_ARGUMENTS_DELTA = "response.function_call_arguments.delta"
+        RESPONSE_FUNCTION_CALL_ARGUMENTS_DONE = "response.function_call_arguments.done"
         ERROR = "error"
 
     def __init__(
@@ -98,6 +100,8 @@ class RealtimeLLMComponent:
         instructions: Optional[str] = None,
         input_audio_transcription: Optional[Dict[str, Any]] = None,
         turn_detection: Optional[Dict[str, Any]] = None,
+        tools: Optional[list] = None,
+        tool_choice: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         GA Realtime API session.update 이벤트 전송
@@ -127,6 +131,11 @@ class RealtimeLLMComponent:
             audio_input["transcription"] = input_audio_transcription
         if audio_input:
             session_config["audio"] = {"input": audio_input}
+
+        if tools:
+            session_config["tools"] = tools
+        if tool_choice:
+            session_config["tool_choice"] = tool_choice
 
         await self._send_event(
             {
@@ -229,6 +238,16 @@ class RealtimeLLMComponent:
             result["response_audio"] = b"".join(audio_chunks)
 
         return result
+
+    async def send_function_call_output(self, call_id: str, output: str) -> None:
+        await self._send_event({
+            "type": "conversation.item.create",
+            "item": {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": output,
+            },
+        })
 
     async def close(self) -> None:
         if self.ws:

--- a/GoGoGolem/src/ai/interaction/server/dto/realtime.py
+++ b/GoGoGolem/src/ai/interaction/server/dto/realtime.py
@@ -23,6 +23,7 @@ class RealtimeMessageType(str, Enum):
     SPEECH_STARTED = "SPEECH_STARTED"
     TRANSCRIPT = "TRANSCRIPT"
     TEXT_DELTA = "TEXT_DELTA"
+    EXPRESSION = "EXPRESSION"
     RESPONSE_END = "RESPONSE_END"
     STREAM_ERROR = "STREAM_ERROR"
 
@@ -126,6 +127,14 @@ class TextDeltaResponse(BaseModel):
     type: str = RealtimeMessageType.TEXT_DELTA
     session_id: str
     delta: str
+
+
+class ExpressionResponse(BaseModel):
+    """골렘 표정 (TEXT_DELTA 전에 먼저 전송)"""
+
+    type: str = RealtimeMessageType.EXPRESSION
+    session_id: str
+    emotion: str
 
 
 class ResponseEndResponse(BaseModel):

--- a/GoGoGolem/src/ai/interaction/server/router/realtime/v1.py
+++ b/GoGoGolem/src/ai/interaction/server/router/realtime/v1.py
@@ -78,21 +78,45 @@ async def stream_openai_responses(
                     )
                     logger.debug(f"Transcript: {transcript[:50]}...")
 
-            # 텍스트 델타
-            elif event_type == realtime.EventType.RESPONSE_TEXT_DELTA:
-                delta = event.get("delta", "")
-                if delta:
-                    full_text += delta
+            # function_call_arguments.delta — 무시 (arguments.done에서 전체 처리)
+            elif event_type == realtime.EventType.RESPONSE_FUNCTION_CALL_ARGUMENTS_DELTA:
+                pass
+
+            # function_call_arguments.done — 파싱, fake streaming, RESPONSE_END 전송
+            elif event_type == realtime.EventType.RESPONSE_FUNCTION_CALL_ARGUMENTS_DONE:
+                try:
+                    parsed = json.loads(event.get("arguments", "{}"))
+                except json.JSONDecodeError:
+                    parsed = {}
+                expression = parsed.get("expression", "Neutral")
+                full_text = parsed.get("text", "")
+                call_id = event.get("call_id", "")
+
+                # 표정 먼저 전송 (텍스트 스트리밍 시작 전)
+                await client_ws.send_json(
+                    {
+                        "type": MessageType.EXPRESSION,
+                        "session_id": session_id,
+                        "emotion": expression,
+                    }
+                )
+
+                # Fake streaming: 10글자씩, 10ms 간격
+                CHUNK = 10
+                DELAY = 0.01
+                for i in range(0, len(full_text), CHUNK):
+                    chunk = full_text[i:i + CHUNK]
                     await client_ws.send_json(
                         {
                             "type": MessageType.TEXT_DELTA,
                             "session_id": session_id,
-                            "delta": delta,
+                            "delta": chunk,
                         }
                     )
+                    if i + CHUNK < len(full_text):
+                        await asyncio.sleep(DELAY)
 
-            # 응답 완료
-            elif event_type == realtime.EventType.RESPONSE_DONE:
+                # RESPONSE_END (emotion 없음)
                 await client_ws.send_json(
                     {
                         "type": MessageType.RESPONSE_END,
@@ -100,8 +124,15 @@ async def stream_openai_responses(
                         "full_text": full_text,
                     }
                 )
-                logger.info(f"Response completed: {full_text[:50]}...")
-                full_text = ""  # 다음 응답을 위해 초기화
+                logger.info(f"Response completed (expression={expression}): {full_text[:50]}...")
+                full_text = ""
+
+                # OpenAI conversation context 클린업
+                await realtime.send_function_call_output(call_id, json.dumps({"status": "delivered"}))
+
+            # 응답 완료 (tool call 처리 후 상태 초기화용)
+            elif event_type == realtime.EventType.RESPONSE_DONE:
+                full_text = ""  # 혹시 남은 상태 초기화
                 # break 하지 않음 - 멀티턴을 위해 계속 대기
 
             # 에러 (OpenAI 에러 구조: error.type, error.code, error.message, error.param, error.event_id)

--- a/GoGoGolem/src/ai/interaction/speech/components/realtime/llm_realtime_speech_v1.py
+++ b/GoGoGolem/src/ai/interaction/speech/components/realtime/llm_realtime_speech_v1.py
@@ -5,13 +5,17 @@ OpenAI Realtime API를 사용하여 실시간 음성 처리를 수행합니다.
 Server VAD를 지원하며, 세션 내에서 자동으로 대화 컨텍스트를 유지합니다.
 """
 
+import json
 import logging
-from typing import Optional
+import os
+from typing import Any, Dict, Optional
 
 from interaction.core.components.realtime_components.realtime_llm_component import (
     RealtimeLLMComponent,
 )
 from interaction.speech.prompts.text_to_text_v2 import SYSTEM_PROMPT, MODEL_CONFIG
+
+_TOOL_PATH = os.path.join(os.path.dirname(__file__), "../../prompts/respond_with_expression_tool.json")
 
 logger = logging.getLogger(__name__)
 
@@ -62,4 +66,13 @@ class LLMRealtimeSpeechV1(RealtimeLLMComponent):
         logger.info(
             f"LLMRealtimeSpeechV1 initialized with model: {model}, "
             f"transcription: {transcription_model} ({transcription_language})"
+        )
+
+    async def configure_session(self, **kwargs) -> Dict[str, Any]:
+        with open(_TOOL_PATH, encoding="utf-8") as f:
+            tool = json.load(f)
+        return await super().configure_session(
+            tools=[tool],
+            tool_choice="required",
+            **kwargs
         )

--- a/GoGoGolem/src/ai/interaction/speech/prompts/respond_with_expression_tool.json
+++ b/GoGoGolem/src/ai/interaction/speech/prompts/respond_with_expression_tool.json
@@ -1,0 +1,20 @@
+{
+  "type": "function",
+  "name": "respond_with_expression",
+  "description": "Deliver the golem's response to the player. Always use this function to send your response. Choose expression that matches the emotional tone of your text.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "expression": {
+        "type": "string",
+        "enum": ["Neutral", "Happy", "Sad", "Angry", "Surprise", "Fear"],
+        "description": "Golem's facial expression. Happy=joy/excitement, Sad=empathy/comfort, Angry=rare frustration, Surprise=unexpected discovery, Fear=danger, Neutral=default/thinking/hints"
+      },
+      "text": {
+        "type": "string",
+        "description": "The golem's response text in Korean"
+      }
+    },
+    "required": ["expression", "text"]
+  }
+}

--- a/GoGoGolem/src/ai/interaction/speech/prompts/text_to_text_v2.py
+++ b/GoGoGolem/src/ai/interaction/speech/prompts/text_to_text_v2.py
@@ -298,6 +298,19 @@ User: 여기 뭐 있어?
 Golem: 현재 위치는 바람숲입니다. 이곳에는 나무와 다양한 아이템이 있습니다. 탐색을 권장합니다.
 (Too mechanical, AI-like, uses formal/informational tone)
 
+═══════════════════════════════════════════════════════════════
+EXPRESSION SELECTION
+═══════════════════════════════════════════════════════════════
+
+Always respond using the respond_with_expression function.
+Choose expression based on the emotional tone of your response:
+- Happy: excitement, joy, discovery, encouragement
+- Sad: empathy, comfort, when player is frustrated
+- Angry: mild frustration (use rarely)
+- Surprise: unexpected discovery, shock
+- Fear: scary situations, danger
+- Neutral: default, thinking, explaining hints
+
     """
 
     MODEL_CONFIG: ClassVar[dict] = {

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/AIBridge/RealtimeWebSocketClient.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/AIBridge/RealtimeWebSocketClient.cs
@@ -45,6 +45,7 @@ namespace Multimodal.AIBridge
             public const string SPEECH_STARTED = "SPEECH_STARTED";
             public const string TRANSCRIPT = "TRANSCRIPT";
             public const string TEXT_DELTA = "TEXT_DELTA";
+            public const string EXPRESSION = "EXPRESSION";
             public const string RESPONSE_END = "RESPONSE_END";
             public const string STREAM_ERROR = "STREAM_ERROR";
         }
@@ -61,7 +62,9 @@ namespace Multimodal.AIBridge
 
         public event Action<string> OnTextDelta;
 
-        public event Action<string> OnResponseEnd;
+        public event Action<string> OnExpression; // emotion 문자열
+
+        public event Action<string> OnResponseEnd; // full_text
 
         public event Action<string, string> OnError; // (error_code, error_message)
         #endregion
@@ -289,6 +292,10 @@ namespace Multimodal.AIBridge
                         HandleTextDelta(message);
                         break;
 
+                    case MessageType.EXPRESSION:
+                        HandleExpression(message);
+                        break;
+
                     case MessageType.RESPONSE_END:
                         HandleResponseEnd(message);
                         break;
@@ -338,6 +345,13 @@ namespace Multimodal.AIBridge
                 // 실시간 스트리밍 - UI 업데이트
                 OnTextDelta?.Invoke(delta);
             }
+        }
+
+        private void HandleExpression(JObject message)
+        {
+            var emotion = message["emotion"]?.ToString() ?? "Neutral";
+            Debug.Log($"[Realtime] Expression: {emotion}");
+            OnExpression?.Invoke(emotion);
         }
 
         private void HandleResponseEnd(JObject message)


### PR DESCRIPTION
## 변경 내용

골렘이 대화 응답과 함께 표정을 자동으로 결정하도록 구현했습니다.

### 동작 방식
OpenAI Realtime API의 function tool calling을 사용해 골렘 응답 시
`expression`(표정)과 `text`(대사)를 동시에 생성합니다.

**메시지 순서**
EXPRESSION → TEXT_DELTA (스트리밍) → RESPONSE_END

표정이 텍스트보다 먼저 전달되어 골렘이 말하기 시작할 때 표정이 변경됩니다.

### AI 서버 변경
- `respond_with_expression` function tool 추가 (expression enum + text)
- `EXPRESSION` 메시지 타입 신규 추가 (DTO)
- Python fake streaming으로 텍스트 순차 전달 유지

### Unity 변경 (AIBridge)
- `RealtimeWebSocketClient`: `OnExpression` 이벤트 추가, EXPRESSION 메시지 파싱

## 팀원 추가 작업 필요
`RealtimeVoiceManager.cs` — `OnExpression` 구독 및 `OnEmotionReceived` 연결
(별도 공유된 스펙 참고)

## 테스트
AI 서버 단독 마이크 테스트 통과 ✅
[Expression] Happy   ← 텍스트 전에 먼저 도착
안녕하세요! (^_^)  ← 스트리밍
[Response complete]