### PR TITLE
Feat/golem expression unity

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Forest.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Forest.unity
@@ -543,6 +543,17 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7431533587824991313, guid: 828c255f9d6c1ca45b52360f112c64eb, type: 3}
   m_PrefabInstance: {fileID: 143030883}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &143030887 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9135575588382599449, guid: 828c255f9d6c1ca45b52360f112c64eb, type: 3}
+  m_PrefabInstance: {fileID: 143030883}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dcbeeb907039eb8468900f62a1d33e6e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &143030888 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2005445015085476028, guid: 828c255f9d6c1ca45b52360f112c64eb, type: 3}
@@ -9663,6 +9674,7 @@ MonoBehaviour:
   playerTransform: {fileID: 1697612975}
   voiceManager: {fileID: 147977249}
   uiView: {fileID: 1598776806}
+  golemFaceController: {fileID: 143030887}
   requestEnterDialogueEvent: {fileID: 11400000, guid: 7ab5d8b65d1adb9488a8ed88428bcbad, type: 2}
   requestHideHUDEvent: {fileID: 11400000, guid: 0721ea1755460b844a5ee06d7b5be039, type: 2}
   requestShowHUDEvent: {fileID: 11400000, guid: 342c4e1f9b5c74c44baf926a5ee4a790, type: 2}
@@ -13793,6 +13805,30 @@ PrefabInstance:
     - target: {fileID: 3167089661266411046, guid: d93896b5398afa341baffddea53e809f, type: 3}
       propertyPath: m_Name
       value: InventoryCanvas New
+      objectReference: {fileID: 0}
+    - target: {fileID: 3969570175738909590, guid: d93896b5398afa341baffddea53e809f, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3969570175738909590, guid: d93896b5398afa341baffddea53e809f, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3969570175738909590, guid: d93896b5398afa341baffddea53e809f, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3969570175738909590, guid: d93896b5398afa341baffddea53e809f, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 3969570175738909590, guid: d93896b5398afa341baffddea53e809f, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -40
+      objectReference: {fileID: 0}
+    - target: {fileID: 5511129074042963052, guid: d93896b5398afa341baffddea53e809f, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5612785563698385270, guid: d93896b5398afa341baffddea53e809f, type: 3}
       propertyPath: m_Pivot.x

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Voice/GolemDialogueSceneController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Voice/GolemDialogueSceneController.cs
@@ -329,7 +329,7 @@ public class GolemDialogueSceneController : MonoBehaviour
     {
         if (golemFaceController == null) return;
 
-        if (Enum.TryParse<GolemFaceController.GolemEmotion>(emotionName, out var emotion))
+        if (Enum.TryParse<GolemFaceController.GolemEmotion>(emotionName, ignoreCase: true, out var emotion))
             golemFaceController.SetFace(emotion);
         else
             golemFaceController.SetFace(GolemFaceController.GolemEmotion.Neutral);

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Voice/GolemDialogueSceneController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Voice/GolemDialogueSceneController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -56,6 +57,9 @@ public class GolemDialogueSceneController : MonoBehaviour
     [Header("UI")]
     [SerializeField] private GolemDialogueUIView uiView;
 
+    [Header("표정")]
+    [SerializeField] private GolemFaceController golemFaceController;
+
     [Header("Event Channels")]
     [SerializeField] private GameEvent requestEnterDialogueEvent;
     [SerializeField] private GameEvent requestHideHUDEvent;
@@ -76,11 +80,12 @@ public class GolemDialogueSceneController : MonoBehaviour
         requestEnterDialogueEvent?.Register(EnterDialogueMode);
 
         if (voiceManager == null) return;
-        voiceManager.OnConnected       += HandleVoiceConnected;
-        voiceManager.OnSpeechDetected  += HandleSpeechDetected;
-        voiceManager.OnTranscript      += HandleTranscript;
-        voiceManager.OnStreamingText   += HandleStreamingText;
-        voiceManager.OnAIResponse      += HandleAIResponse;
+        voiceManager.OnConnected        += HandleVoiceConnected;
+        voiceManager.OnSpeechDetected   += HandleSpeechDetected;
+        voiceManager.OnTranscript       += HandleTranscript;
+        voiceManager.OnStreamingText    += HandleStreamingText;
+        voiceManager.OnAIResponse       += HandleAIResponse;
+        voiceManager.OnEmotionReceived  += HandleEmotionReceived;
     }
 
     private void OnDisable()
@@ -88,11 +93,12 @@ public class GolemDialogueSceneController : MonoBehaviour
         requestEnterDialogueEvent?.Unregister(EnterDialogueMode);
 
         if (voiceManager == null) return;
-        voiceManager.OnConnected       -= HandleVoiceConnected;
-        voiceManager.OnSpeechDetected  -= HandleSpeechDetected;
-        voiceManager.OnTranscript      -= HandleTranscript;
-        voiceManager.OnStreamingText   -= HandleStreamingText;
-        voiceManager.OnAIResponse      -= HandleAIResponse;
+        voiceManager.OnConnected        -= HandleVoiceConnected;
+        voiceManager.OnSpeechDetected   -= HandleSpeechDetected;
+        voiceManager.OnTranscript       -= HandleTranscript;
+        voiceManager.OnStreamingText    -= HandleStreamingText;
+        voiceManager.OnAIResponse       -= HandleAIResponse;
+        voiceManager.OnEmotionReceived  -= HandleEmotionReceived;
     }
 
     /// <summary>GolemInteractable의 requestEnterDialogueEvent SO를 통해 호출</summary>
@@ -316,5 +322,16 @@ public class GolemDialogueSceneController : MonoBehaviour
         }
         // 다음 응답의 첫 TEXT_DELTA에서 말풍선 초기화
         _needsClearGolemText = true;
+    }
+
+    /// <summary>EXPRESSION 메시지 수신 → 골렘 표정 변경 (TEXT_DELTA 스트리밍 시작 전)</summary>
+    private void HandleEmotionReceived(string emotionName)
+    {
+        if (golemFaceController == null) return;
+
+        if (Enum.TryParse<GolemFaceController.GolemEmotion>(emotionName, out var emotion))
+            golemFaceController.SetFace(emotion);
+        else
+            golemFaceController.SetFace(GolemFaceController.GolemEmotion.Neutral);
     }
 }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Voice/RealtimeVoiceManager.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Voice/RealtimeVoiceManager.cs
@@ -67,6 +67,9 @@ namespace Multimodal.Voice
         /// AI 최종 응답 (전체 텍스트)
         public event Action<string> OnAIResponse;
 
+        /// AI 응답 직전 골렘 표정 (GolemEmotion enum 이름 문자열)
+        public event Action<string> OnEmotionReceived;
+
         /// 에러 발생 시 발생
         public event Action<string, string> OnError; // (error_code, error_message)
         #endregion
@@ -96,6 +99,7 @@ namespace Multimodal.Voice
             _realtimeClient.OnSpeechStarted += HandleSpeechStarted;
             _realtimeClient.OnTranscript += HandleTranscript;
             _realtimeClient.OnTextDelta += HandleTextDelta;
+            _realtimeClient.OnExpression += HandleExpression;
             _realtimeClient.OnResponseEnd += HandleResponseEnd;
             _realtimeClient.OnError += HandleError;
 
@@ -296,14 +300,18 @@ namespace Multimodal.Voice
             DebugLog($"Text delta: {delta}", verbose: true);
         }
 
+        private void HandleExpression(string emotion)
+        {
+            DebugLog($"Expression: {emotion}");
+            OnEmotionReceived?.Invoke(emotion);
+        }
+
         private void HandleResponseEnd(string fullText)
         {
             DebugLog($"Response complete: {fullText}");
 
-            // 최종 응답
             OnAIResponse?.Invoke(fullText);
 
-            // 초기화 (다음 턴 준비)
             _currentResponse = "";
         }
 


### PR DESCRIPTION
# 골렘 대화 표정 변화 - 유니티
## 개요

- 골렘 대화 중 AI 서버의 EXPRESSION 메시지를 수신해 실시간으로 골렘 표정을 변경하는 기능 추가
- RealtimeVoiceManager에 OnEmotionReceived 이벤트를 추가하고 RealtimeWebSocketClient.OnExpression을 구독
- GolemDialogueSceneController에서 OnEmotionReceived 이벤트를 받아 GolemFaceController.SetFace() 호출

## 동작 흐름

- EXPRESSION 수신 → SetFace() 적용 → TEXT_DELTA 스트리밍 → 말풍선 표시
- 지원 표정: Neutral / Happy / Sad / Angry / Surprise / Fear
