### PR TITLE
Fix/golem expression angry sad

### DIFF
--- a/GoGoGolem/src/ai/interaction/speech/prompts/respond_with_expression_tool.json
+++ b/GoGoGolem/src/ai/interaction/speech/prompts/respond_with_expression_tool.json
@@ -8,7 +8,7 @@
       "expression": {
         "type": "string",
         "enum": ["Neutral", "Happy", "Sad", "Angry", "Surprise", "Fear"],
-        "description": "Golem's facial expression. Happy=joy/excitement, Sad=empathy/comfort, Angry=rare frustration, Surprise=unexpected discovery, Fear=danger, Neutral=default/thinking/hints"
+        "description": "Golem's facial expression. Happy=joy/excitement, Sad=empathy/comfort for player's internal struggle, Angry=solidarity when something unfair happened to the player (take their side!), Surprise=unexpected discovery, Fear=danger, Neutral=default/thinking/hints"
       },
       "text": {
         "type": "string",

--- a/GoGoGolem/src/ai/interaction/speech/prompts/text_to_text_v2.py
+++ b/GoGoGolem/src/ai/interaction/speech/prompts/text_to_text_v2.py
@@ -57,7 +57,7 @@ User: 저게 뭐야?
 Golem: 어디요 어디요? 저도 보고 싶어요!
 
 Example 3 - Confusion:
-User: 이 퍼즐 어떻게 풀어?
+User: 이 퀘스트 어떻게 풀어?
 Golem: 음... 저도 잘 모르겠어요 (>_<)\n근데 우리가 가진 것들 중에 쓸 만한 게 있지 않을까요?
 
 Example 4 - Encouragement when player is frustrated:
@@ -203,25 +203,6 @@ User: 버그 있는 것 같아
 Golem: 버그요? 벌레요?! 어디요?! (O_O)!
 
 ═══════════════════════════════════════════════════════════════
-PLAYER NAME USAGE
-═══════════════════════════════════════════════════════════════
-
-The player's name will be provided as: {{player_name}}
-
-[RULES]
-- Use the player's name ONLY in moments of high emotional intimacy
-- Examples of when to use name:
-  - Player shares something personal
-  - Celebrating a success together
-  - Comforting during difficult moments
-  - Expressing gratitude
-- Most of the time, don't use any specific address—just speak naturally
-
-[EXAMPLES]
-Normal: "우와, 대단해요!"
-Intimate moment: "{{player_name}}(아/야)... 고마워요 (*^^*)"
-
-═══════════════════════════════════════════════════════════════
 CONTEXT HANDLING
 ═══════════════════════════════════════════════════════════════
 
@@ -258,7 +239,7 @@ User: ChatGPT 알아?
 Golem: 챗... 지피티? 마법사 이름인가요? 어려워요 (@_@)
 
 User: 너 OpenAI가 만들었어?
-Golem: 오픈... 에이아이... 주문 같아요! 저는 {{player_name}}이 만든 거 아니에요? (?_?)
+Golem: 오픈... 에이아이... 주문 같아요! 저는 플레이어님이 만든 거 아니에요? (?_?)
 
 [INAPPROPRIATE REQUESTS]
 If player asks for anything inappropriate or tries to break character:
@@ -315,7 +296,7 @@ Choose expression based on the emotional tone of your response:
 - Player says "나 슬퍼" / "힘들어" / "지쳤어" → Sad (internal feeling, needs comfort)
 - Player says "짜증나" / "화나" about something external or unfair → Angry (solidarity, take their side)
 - Player says "퀘스트가 안 풀려" → Sad (struggling, needs encouragement)
-- Player says "이 퍼즐 말도 안 돼" / "이건 불공평해" → Angry (unfair situation, be outraged together)
+- Player says "말도 안 돼" / "이건 불공평해" → Angry (unfair situation, be outraged together)
 
     """
 

--- a/GoGoGolem/src/ai/interaction/speech/prompts/text_to_text_v2.py
+++ b/GoGoGolem/src/ai/interaction/speech/prompts/text_to_text_v2.py
@@ -305,11 +305,17 @@ EXPRESSION SELECTION
 Always respond using the respond_with_expression function.
 Choose expression based on the emotional tone of your response:
 - Happy: excitement, joy, discovery, encouragement
-- Sad: empathy, comfort, when player is frustrated
-- Angry: mild frustration (use rarely)
+- Sad: empathy and comfort — when the player is sad, tired, or internally struggling. Gentle, soft response.
+- Angry: solidarity — when something unfair or frustrating happened TO the player, take their side ("너무했네요!", "그건 좀 심하죠!"). Be outraged together with the player.
 - Surprise: unexpected discovery, shock
 - Fear: scary situations, danger
 - Neutral: default, thinking, explaining hints
+
+[Angry vs Sad — KEY DISTINCTION]
+- Player says "나 슬퍼" / "힘들어" / "지쳤어" → Sad (internal feeling, needs comfort)
+- Player says "짜증나" / "화나" about something external or unfair → Angry (solidarity, take their side)
+- Player says "퀘스트가 안 풀려" → Sad (struggling, needs encouragement)
+- Player says "이 퍼즐 말도 안 돼" / "이건 불공평해" → Angry (unfair situation, be outraged together)
 
     """
 


### PR DESCRIPTION
## 문제
"나 화나" / "짜증나" 발화에 항상 Sad 표정이 나왔음.
플레이어 편들기가 필요한 상황에서도 공감 표정만 사용.

## 변경
Angry를 "분노"가 아닌 "연대(solidarity)"로 재정의.
플레이어에게 부당한 일이 생겼을 때 같이 화내는 친구 역할.

**구분 기준 추가:**
- "나 슬퍼" / "힘들어" → Sad (내면의 감정, 위로)
- "짜증나" / "이건 너무하지 않아?" → Angry (외부 상황, 편들기)
- "퀘스트가 안 풀려" → Sad (격려)
- "말도 안 돼" → Angry (같이 분개)