### PR TITLE
fix: mute background music during golem voice dialogue

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Forest.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Forest.unity
@@ -9675,6 +9675,7 @@ MonoBehaviour:
   voiceManager: {fileID: 147977249}
   uiView: {fileID: 1598776806}
   golemFaceController: {fileID: 143030887}
+  backgroundMusicSource: {fileID: 637202865}
   requestEnterDialogueEvent: {fileID: 11400000, guid: 7ab5d8b65d1adb9488a8ed88428bcbad, type: 2}
   requestHideHUDEvent: {fileID: 11400000, guid: 0721ea1755460b844a5ee06d7b5be039, type: 2}
   requestShowHUDEvent: {fileID: 11400000, guid: 342c4e1f9b5c74c44baf926a5ee4a790, type: 2}

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Voice/GolemDialogueSceneController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Voice/GolemDialogueSceneController.cs
@@ -60,6 +60,10 @@ public class GolemDialogueSceneController : MonoBehaviour
     [Header("표정")]
     [SerializeField] private GolemFaceController golemFaceController;
 
+    [Header("BGM")]
+    [Tooltip("BackgroundMusic 오브젝트의 AudioSource — 대화 중 음소거")]
+    [SerializeField] private AudioSource backgroundMusicSource;
+
     [Header("Event Channels")]
     [SerializeField] private GameEvent requestEnterDialogueEvent;
     [SerializeField] private GameEvent requestHideHUDEvent;
@@ -113,6 +117,7 @@ public class GolemDialogueSceneController : MonoBehaviour
         // 1. 플레이어 조작만 차단 (모델은 카메라 전환 시점에 숨김)
         if (playerController != null) playerController.enabled = false;
         if (playerInteraction != null) playerInteraction.enabled = false;
+        if (backgroundMusicSource != null) backgroundMusicSource.volume = 0f;
         requestHideHUDEvent?.Raise();
 
         // 2. 골렘 회전 시작 → 완료 후 카메라 전환 + UI 표시
@@ -253,6 +258,7 @@ public class GolemDialogueSceneController : MonoBehaviour
         if (playerController != null) playerController.enabled = true;
         if (playerInteraction != null) playerInteraction.enabled = true;
         if (playerModel != null) playerModel.SetActive(true);
+        if (backgroundMusicSource != null) backgroundMusicSource.volume = 1f;
         requestShowHUDEvent?.Raise();
 
         uiView.Hide();


### PR DESCRIPTION
### Summary
음성 대화 시작(EnterDialogueMode) 시 BackgroundMusic AudioSource 볼륨을 0으로 설정
대화 종료(ExitDialogueMode) 시 볼륨 1로 복원
GolemDialogueSceneController에 backgroundMusicSource SerializeField 추가 — Inspector에서 BackgroundMusic 오브젝트의 AudioSource 연결 필요

### Test plan

- [x] Forest 씬에서 Golem에 인터랙션 → 대화 진입 시 배경음 소거 확인
- [x] Esc로 대화 종료 시 배경음 복원 확인
- [x] Inspector: GolemDialogueSceneController의 Background Music Source 필드에 BackgroundMusic 오브젝트 드래그 연결