### PR TITLE
fix: resolve white border artifact on intro scene black background

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Intro.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Intro.unity
@@ -4254,7 +4254,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_PixelsPerUnitMultiplier: 100
 --- !u!222 &1610409010
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -4388,7 +4388,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_PixelsPerUnitMultiplier: 100
 --- !u!222 &1649735920
 CanvasRenderer:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- Intro 씬 검은 배경 Image 컴포넌트 2개의 `PixelsPerUnitMultiplier`를 1 → 100으로 수정
- `PixelsPerUnitMultiplier = 1`일 때 스프라이트 픽셀 밀도가 캔버스 크기 대비 너무 낮게 매핑되어 화면 가장자리에 흰색 테두리가 노출되던 문제 수정

## Root cause
Unity Image 컴포넌트의 `PixelsPerUnitMultiplier`가 1로 설정되면, 스프라이트 픽셀이 1:1 유닛 비율로 렌더링되어 캔버스 가장자리 픽셀이 커버되지 않음. 기본 배경(흰색)이 그대로 노출됨.

## Test plan
- [x] 인트로 씬 실행 시 화면 가장자리에 흰색 테두리가 보이지 않는지 확인
- [x] 다양한 해상도/화면 비율에서 검은 배경이 완전히 채워지는지 확인