### PR TITLE
fix: add docker image prune before pull to prevent disk full errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,7 +129,10 @@ jobs:
             # 기존 컨테이너 중지 및 제거
             docker stop gogo-golem-ai-server || true
             docker rm gogo-golem-ai-server || true
-            
+
+            # 사용하지 않는 이미지 정리 (디스크 공간 확보)
+            docker image prune -af || true
+
             # 새 이미지 pull
             echo "Pulling image: ${IMAGE_TAG}"
             docker pull ${IMAGE_TAG}


### PR DESCRIPTION
EC2 서버에 이전 Docker 이미지가 누적되어 디스크가 꽉 차는 문제 방지.
새 이미지 pull 전 사용하지 않는 이미지를 정리한다.