### PR TITLE
Fix/night exit room. 방에서 일어나는 일들이 모두 일어난 뒤에서야 방 밖으로 나갈 수 있도록 수정. 

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
@@ -906,7 +906,7 @@ MonoBehaviour:
   letterWritePresenter: {fileID: 2025068437}
   letterDesk: {fileID: 112640438}
   bedInteraction: {fileID: 987776660}
-  exitDoor: {fileID: 0}
+  exitDoor: {fileID: 520658544}
   enableDebugLogs: 1
 --- !u!4 &339390117
 Transform:

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Room/RoomStateManager.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Room/RoomStateManager.cs
@@ -32,6 +32,11 @@ public class RoomStateManager : MonoBehaviour
     [Header("Exit Door")]
     [SerializeField] private ChangeSceneInteraction exitDoor;
 
+    // [DEMO 삭제 대상] letterReadPresenter 필드, OnEnable/OnDisable 구독 코드, HandleLetterReadPanelClosed 메서드,
+    //                  ApplyMorning의 exitDoor.SetCanInteract(false) → true 로 되돌릴 것
+    [Header("[DEMO] 데모 시연용 — 데모 후 삭제")]
+    [SerializeField] private LetterReadPresenter letterReadPresenter;
+
     [Header("Debug")]
     [SerializeField] private bool enableDebugLogs = true;
 
@@ -47,6 +52,10 @@ public class RoomStateManager : MonoBehaviour
 
         if (bedInteraction != null)
             bedInteraction.OnSlept += HandleSlept;
+
+        // [DEMO 삭제 대상] 아래 구독 코드 제거
+        if (letterReadPresenter != null)
+            letterReadPresenter.OnPanelToggled += HandleLetterReadPanelClosed;
     }
 
     private void OnDisable()
@@ -59,12 +68,17 @@ public class RoomStateManager : MonoBehaviour
 
         if (bedInteraction != null)
             bedInteraction.OnSlept -= HandleSlept;
+
+        // [DEMO 삭제 대상] 아래 구독 해제 코드 제거
+        if (letterReadPresenter != null)
+            letterReadPresenter.OnPanelToggled -= HandleLetterReadPanelClosed;
     }
 
     private void Start()
     {
         // GameManager가 없는 씬에서도 자동 생성되도록 보장
         _ = GameManager.Instance;
+
         ApplyState(RoomState.BeforeLetter);
     }
 
@@ -180,9 +194,16 @@ public class RoomStateManager : MonoBehaviour
             letterDesk.SetCanInteract(true);
         }
 
-        // 문: 활성
+        // [DEMO 삭제 대상] false → true 로 되돌릴 것 (편지 읽기 전 차단용)
         if (exitDoor != null)
-            exitDoor.SetCanInteract(true);
+            exitDoor.SetCanInteract(false);
+    }
+
+    // [DEMO 삭제 대상] 이 메서드 전체 제거
+    private void HandleLetterReadPanelClosed(bool isOpen)
+    {
+        if (!isOpen)
+            exitDoor?.SetCanInteract(true);
     }
 
     // ── Debug ────────────────────────────────────────────────────

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Systems/Interactions/Scripts/ChangeSceneInteraction.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Systems/Interactions/Scripts/ChangeSceneInteraction.cs
@@ -41,6 +41,8 @@ public class ChangeSceneInteraction : MonoBehaviour, IInteractable
 
     public void Interact()
     {
+        if (!_canInteract) return;
+
         if (string.IsNullOrEmpty(sceneName))
         {
             Debug.LogError("[ChangeSceneInteraction] sceneName이 설정되지 않았습니다.");

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Systems/Interactions/Scripts/PlayerInteraction.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Systems/Interactions/Scripts/PlayerInteraction.cs
@@ -50,7 +50,7 @@ public class PlayerInteraction : MonoBehaviour
 
     private void OnInteract(InputAction.CallbackContext ctx)
     {
-        if (currentInteractable == null) return;
+        if (currentInteractable == null || !currentInteractable.CanInteract) return;
     
         switch (currentInteractable.InteractionType)
         {


### PR DESCRIPTION
중요: 일부 코드는 내일 데모 시연 이후 삭제해야 합니다. 주석에 잘 표시해놨습니다.

내일 데모를 위해 임시로 만든 코드는 아침에 일어난 뒤에 편지를 확인해야만 밖으로 나갈 수 있도록 합니다. 기획상 버그는 아니라서 위와 같이 처리합니다.