### PR TITLE
Hotfix/gesture again

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
@@ -8846,11 +8846,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _minCutoff
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _positionDeadzone
       value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _handReachZClamp.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _handReachZClamp.y
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _handReachMultiplier
@@ -8874,7 +8882,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _maxArmJumpPerFrame.z
-      value: 0.15
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _normalizeByBodyScale
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _handRotationSmoothing

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
@@ -199,6 +199,8 @@ namespace Demo.GestureDetection
     [Header("Arm Reach Settings")]
     [Tooltip("바디 스케일(어깨 너비) 기준으로 팔 뻗음을 정규화. 카메라 거리 무관하게 동일한 팔 움직임 보장")]
     [SerializeField] private bool _normalizeByBodyScale = true;
+    [Tooltip("어깨 기준 손 target의 Z(깊이) 뻗음 허용 범위 (min, max). 손목을 모을 때 pose 깊이 추정이 튀어 손이 카메라로 돌진/잘리는 현상 방지. 증폭 적용 후 값 기준.")]
+    [SerializeField] private Vector2 _handReachZClamp = new Vector2(-2f, 2f);
 
     [Header("Handedness Stability")]
     [Tooltip("MediaPipe 핸드니스 라벨이 이 프레임 수 이상 연속으로 바뀔 때만 좌우 할당 전환 (순간 flip 방지)")]
@@ -528,6 +530,9 @@ namespace Demo.GestureDetection
       shoulderToWrist.y *= _handAxisMultiplier.y;
       shoulderToWrist.z *= _handAxisMultiplier.z;
       shoulderToWrist   *= _handReachMultiplier;
+
+      // 손목을 모을 때 pose Z 추정이 튀어 손이 카메라로 돌진 → 깊이 뻗음에 절대 한계 적용
+      shoulderToWrist.z = Mathf.Clamp(shoulderToWrist.z, _handReachZClamp.x, _handReachZClamp.y);
 
       OneEuroFilter handFilter  = isLeft ? _leftHandPosFilter  : _rightHandPosFilter;
       OneEuroFilter elbowFilter = isLeft ? _leftElbowPosFilter : _rightElbowPosFilter;

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureRecognizer.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureRecognizer.cs
@@ -104,9 +104,11 @@ namespace Demo.GestureDetection
         {
           // confidence 계산: 프레임 카운트 기반
           float confidence = Mathf.Min(1f, _gestureFrameCount[_currentGestureType] / (float)_holdFrames);
-          
-          Debug.Log($"[GestureRecognizer] {_currentGestureType} detected! Count={_gestureFrameCount[_currentGestureType]}, Confidence={confidence:F2}");
-          
+
+          // holdFrames 도달 첫 프레임에만 로그 (매 프레임 출력 방지)
+          if (_gestureFrameCount[_currentGestureType] == _holdFrames)
+            Debug.Log($"[GestureRecognizer] {_currentGestureType} detected! Count={_gestureFrameCount[_currentGestureType]}, Confidence={confidence:F2}");
+
           return new GestureResult(_currentGestureType, confidence, true, rawResult.Direction);
         }
       }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GesturePlayView.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GesturePlayView.cs
@@ -63,10 +63,12 @@ namespace Demo.GestureDetection.UI
     /// </summary>
     public void UpdateDisplay(DisplayData data)
     {
-      // 1. 데이터 유효성에 따른 Avatar 업데이트
+      // 1. 데이터 유효성 체크
       if (!data.HasValidData)
       {
-        ResetAvatar();
+        // ResetAvatar() 호출 안 함: 두 손이 가까워 한쪽이 잠깐 미검출될 때마다
+        // IK weight가 0으로 즉시 스냅되어 팔이 깜빡인다. GolemLandmarkAnimator의
+        // _dataTimeout(1초) + ReturnTargetsToRest()가 데이터 끊김을 부드럽게 처리한다.
         UpdateHoldProgressBar(0f, false);
         return;
       }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GestureUIController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GestureUIController.cs
@@ -62,20 +62,14 @@ namespace Demo.GestureDetection.UI
     /// </summary>
     public void UpdateGestureResult(GestureResult result)
     {
-      // 타겟 제스처만 반응
-      if (result.Type == _targetGesture && result.IsDetected)
-      {
-        _isActive = true;
+      bool wasActive = _isActive;
+
+      // Recognizer는 활성 전략 하나만 평가 → result.Type은 타겟 또는 None
+      _isActive = result.Type == _targetGesture && result.IsDetected;
+
+      // 비활성 → 활성 전환 시에만 로그 (매 프레임 출력 방지)
+      if (_isActive && !wasActive)
         Debug.Log($"[GestureUIController] {_targetGesture} detected - activating indicator");
-      }
-      else
-      {
-        _isActive = false;
-        if (result.Type != GestureType.None)
-        {
-          Debug.Log($"[GestureUIController] Detected {result.Type}, but target is {_targetGesture}");
-        }
-      }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- **손 깊이(Z) 돌진 수정**
손목을 모을 때 MediaPipe pose Z 추정이 튀어 골렘 손이 카메라 방향으로 돌진하거나 잘리는 현상 수정. 
어깨 기준 Z 뻗음에 절대 클램프(`_handReachZClamp`) 추가.
- **팔 깜빡임 수정**
두 손이 가까워 한쪽이 잠깐 미검출될 때마다 IK weight가 0으로 즉시 스냅되어 팔이 깜빡이던 현상 수정. 
`GesturePlayView`에서 `ResetAvatar()` 즉시 호출을 제거하고, `GolemLandmarkAnimator`의 `_dataTimeout(1초)` + `ReturnTargetsToRest()`가 끊김을 부드럽게 처리하도록 위임.
- **로그 노이즈 감소**
`GestureRecognizer`와 `GestureUIController`에서 매 프레임 출력되던 Debug.Log를 상태 전환 시에만 출력하도록 최적화.

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `GolemLandmarkAnimator.cs` | `_handReachZClamp` 필드 추가 및 Z 클램프 적용 |
| `GesturePlayView.cs` | 미검출 시 `ResetAvatar()` 즉시 호출 제거 |
| `GestureRecognizer.cs` | holdFrames 도달 첫 프레임에만 로그 출력 |
| `GestureUIController.cs` | 비활성→활성 전환 시에만 로그 출력, 불필요한 분기 제거 |
| `Gesture Detection Wind.unity` | Scene 설정 변경 반영 |
