### PR TITLE
Hotfix/room transition and letter presenter

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
@@ -8846,11 +8846,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _minCutoff
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _positionDeadzone
       value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _handReachZClamp.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _handReachZClamp.y
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _handReachMultiplier
@@ -8874,7 +8882,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _maxArmJumpPerFrame.z
-      value: 0.15
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _normalizeByBodyScale
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _handRotationSmoothing

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
@@ -907,6 +907,7 @@ MonoBehaviour:
   letterDesk: {fileID: 112640438}
   bedInteraction: {fileID: 987776660}
   exitDoor: {fileID: 520658544}
+  letterReadPresenter: {fileID: 2025068436}
   enableDebugLogs: 1
 --- !u!4 &339390117
 Transform:

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
@@ -8904,7 +8904,7 @@ RectTransform:
   m_Father: {fileID: 390805422104622915}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -11952,7 +11952,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2927166725123618203}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1427368679984008097}
+        m_TargetAssemblyTypeName: SettingsPresenter, Assembly-CSharp
+        m_MethodName: ResetAllDataAndGoHome
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &5670413968197503670
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12118,7 +12130,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &5885309875298852337
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12725,7 +12737,7 @@ RectTransform:
   m_Father: {fileID: 943481579840445490}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
@@ -199,6 +199,8 @@ namespace Demo.GestureDetection
     [Header("Arm Reach Settings")]
     [Tooltip("바디 스케일(어깨 너비) 기준으로 팔 뻗음을 정규화. 카메라 거리 무관하게 동일한 팔 움직임 보장")]
     [SerializeField] private bool _normalizeByBodyScale = true;
+    [Tooltip("어깨 기준 손 target의 Z(깊이) 뻗음 허용 범위 (min, max). 손목을 모을 때 pose 깊이 추정이 튀어 손이 카메라로 돌진/잘리는 현상 방지. 증폭 적용 후 값 기준.")]
+    [SerializeField] private Vector2 _handReachZClamp = new Vector2(-2f, 2f);
 
     [Header("Handedness Stability")]
     [Tooltip("MediaPipe 핸드니스 라벨이 이 프레임 수 이상 연속으로 바뀔 때만 좌우 할당 전환 (순간 flip 방지)")]
@@ -528,6 +530,9 @@ namespace Demo.GestureDetection
       shoulderToWrist.y *= _handAxisMultiplier.y;
       shoulderToWrist.z *= _handAxisMultiplier.z;
       shoulderToWrist   *= _handReachMultiplier;
+
+      // 손목을 모을 때 pose Z 추정이 튀어 손이 카메라로 돌진 → 깊이 뻗음에 절대 한계 적용
+      shoulderToWrist.z = Mathf.Clamp(shoulderToWrist.z, _handReachZClamp.x, _handReachZClamp.y);
 
       OneEuroFilter handFilter  = isLeft ? _leftHandPosFilter  : _rightHandPosFilter;
       OneEuroFilter elbowFilter = isLeft ? _leftElbowPosFilter : _rightElbowPosFilter;

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureRecognizer.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureRecognizer.cs
@@ -104,9 +104,11 @@ namespace Demo.GestureDetection
         {
           // confidence 계산: 프레임 카운트 기반
           float confidence = Mathf.Min(1f, _gestureFrameCount[_currentGestureType] / (float)_holdFrames);
-          
-          Debug.Log($"[GestureRecognizer] {_currentGestureType} detected! Count={_gestureFrameCount[_currentGestureType]}, Confidence={confidence:F2}");
-          
+
+          // holdFrames 도달 첫 프레임에만 로그 (매 프레임 출력 방지)
+          if (_gestureFrameCount[_currentGestureType] == _holdFrames)
+            Debug.Log($"[GestureRecognizer] {_currentGestureType} detected! Count={_gestureFrameCount[_currentGestureType]}, Confidence={confidence:F2}");
+
           return new GestureResult(_currentGestureType, confidence, true, rawResult.Direction);
         }
       }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GesturePlayView.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GesturePlayView.cs
@@ -63,10 +63,12 @@ namespace Demo.GestureDetection.UI
     /// </summary>
     public void UpdateDisplay(DisplayData data)
     {
-      // 1. 데이터 유효성에 따른 Avatar 업데이트
+      // 1. 데이터 유효성 체크
       if (!data.HasValidData)
       {
-        ResetAvatar();
+        // ResetAvatar() 호출 안 함: 두 손이 가까워 한쪽이 잠깐 미검출될 때마다
+        // IK weight가 0으로 즉시 스냅되어 팔이 깜빡인다. GolemLandmarkAnimator의
+        // _dataTimeout(1초) + ReturnTargetsToRest()가 데이터 끊김을 부드럽게 처리한다.
         UpdateHoldProgressBar(0f, false);
         return;
       }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GestureUIController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GestureUIController.cs
@@ -62,20 +62,14 @@ namespace Demo.GestureDetection.UI
     /// </summary>
     public void UpdateGestureResult(GestureResult result)
     {
-      // 타겟 제스처만 반응
-      if (result.Type == _targetGesture && result.IsDetected)
-      {
-        _isActive = true;
+      bool wasActive = _isActive;
+
+      // Recognizer는 활성 전략 하나만 평가 → result.Type은 타겟 또는 None
+      _isActive = result.Type == _targetGesture && result.IsDetected;
+
+      // 비활성 → 활성 전환 시에만 로그 (매 프레임 출력 방지)
+      if (_isActive && !wasActive)
         Debug.Log($"[GestureUIController] {_targetGesture} detected - activating indicator");
-      }
-      else
-      {
-        _isActive = false;
-        if (result.Type != GestureType.None)
-        {
-          Debug.Log($"[GestureUIController] Detected {result.Type}, but target is {_targetGesture}");
-        }
-      }
     }
 
     /// <summary>

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Systems/Interactions/Scripts/ForestAfternoonController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Systems/Interactions/Scripts/ForestAfternoonController.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.SceneManagement;
@@ -68,11 +69,30 @@ public class ForestAfternoonController : MonoBehaviour
         requestStartDialogueEvent?.Raise("DLG-012");
     }
 
-    // DLG-012 완료 → 씬 전환
+    // DLG-012 완료 → 타임라인 종료까지 대기 후 씬 전환
     private void OnDialogueCompleted()
     {
         if (!_waitingForDialogueComplete) return;
         _waitingForDialogueComplete = false;
+        StartCoroutine(LoadNextSceneAfterTimeline());
+    }
+
+    /// <summary>
+    /// Yarn 대화가 끝나도 컷씬 Timeline이 끝까지 재생될 때까지 대기한 뒤 씬을 전환한다.
+    /// extrapolationMode = Hold라 타임라인이 끝나도 stopped 이벤트가 발생하지 않으므로
+    /// time이 duration에 도달했는지로 종료를 판정한다.
+    /// </summary>
+    private IEnumerator LoadNextSceneAfterTimeline()
+    {
+        if (cutsceneDirector != null)
+        {
+            while (cutsceneDirector.state == PlayState.Playing &&
+                   cutsceneDirector.time < cutsceneDirector.duration)
+            {
+                yield return null;
+            }
+        }
+
         SceneManager.LoadScene(nextScene);
     }
 


### PR DESCRIPTION
## Summary

- **타임라인 종료 후 씬 전환**
다이얼로그(DLG-012)가 완료되어도 컷씬 Timeline이 끝나기 전에 씬이 전환되던 문제 수정. `extrapolationMode = Hold` 상황에서 `stopped` 이벤트가 발생하지 않으므로, `time >= duration` 조건으로 종료를 판정하는 코루틴(`LoadNextSceneAfterTimeline`) 추가.
- **Room 설정 홈 버튼 수정**
Room 씬의 홈 버튼이 정상 동작하지 않던 문제 수정.
- **편지 읽기 Presenter 레퍼런스 연결**
`LetterReadPresenter` 레퍼런스 누락으로 인한 오류 수정.

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `ForestAfternoonController.cs` | 다이얼로그 완료 후 Timeline 재생 종료 대기 코루틴 추가 |
| `Room.unity` | Room 설정 홈 버튼 및 Presenter 레퍼런스 연결 수정 |

## Test Plan

- [X] DLG-012 완료 후 컷씬 Timeline이 끝날 때까지 씬 전환이 지연되는지 확인
- [X] Room 씬에서 홈 버튼이 정상 동작하는지 확인
- [X] 편지 읽기 기능이 오류 없이 동작하는지 확인