### PR TITLE
Test/gesture compare

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
@@ -8846,11 +8846,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _minCutoff
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _positionDeadzone
       value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _handReachZClamp.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _handReachZClamp.y
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _handReachMultiplier
@@ -8874,7 +8882,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _maxArmJumpPerFrame.z
-      value: 0.15
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _normalizeByBodyScale
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _handRotationSmoothing

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
@@ -907,6 +907,7 @@ MonoBehaviour:
   letterDesk: {fileID: 112640438}
   bedInteraction: {fileID: 987776660}
   exitDoor: {fileID: 520658544}
+  letterReadPresenter: {fileID: 2025068436}
   enableDebugLogs: 1
 --- !u!4 &339390117
 Transform:

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
@@ -8904,7 +8904,7 @@ RectTransform:
   m_Father: {fileID: 390805422104622915}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -11952,7 +11952,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2927166725123618203}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1427368679984008097}
+        m_TargetAssemblyTypeName: SettingsPresenter, Assembly-CSharp
+        m_MethodName: ResetAllDataAndGoHome
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &5670413968197503670
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12118,7 +12130,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &5885309875298852337
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12725,7 +12737,7 @@ RectTransform:
   m_Father: {fileID: 943481579840445490}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Globalization;
 using UnityEngine;
 using UnityEngine.Animations.Rigging;
 using Mediapipe.Tasks.Vision.HandLandmarker;
@@ -19,6 +22,12 @@ namespace Demo.GestureDetection
   /// </summary>
   public class GolemLandmarkAnimator : MonoBehaviour
   {
+    // 떨림 보정 필터 종류 (평가/비교 측정용)
+    public enum JitterFilterMode { None, MovingAverage, OneEuro }
+
+    // CSV로 기록할 손 (golem 기준 좌/우 hand target)
+    public enum RecordJoint { RightHand, LeftHand }
+
     // ─────────────────────────────────────────────────────────────────────────
     // 스레드 안전 스냅샷
     // MediaPipe 콜백은 백그라운드 스레드에서 실행.
@@ -33,6 +42,86 @@ namespace Demo.GestureDetection
       public Vector3[] hand1;      // Hand 1 landmarks [0..20]
       public string    hand0Label; // "Left" or "Right" (MediaPipe 기준)
       public bool      valid;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 위치 필터 공통 인터페이스 (런타임에 종류 교체 → 평가 비교)
+    // maxDelta(이상치 제거)는 세 모드 모두 동일 적용 → 스무딩 거동만 비교됨
+    // ─────────────────────────────────────────────────────────────────────────
+    private interface IPositionFilter
+    {
+      Vector3 Update(Vector3 raw, float dt, Vector3 maxDelta);
+      void Reset(Vector3 v);
+    }
+
+    // 스무딩 없음: 이상치 클램프만 적용 (필터 off 기준선)
+    private class NoFilter : IPositionFilter
+    {
+      private Vector3 _prev;
+      private bool    _init;
+
+      public Vector3 Update(Vector3 raw, float dt, Vector3 maxDelta)
+      {
+        if (!_init) { _prev = raw; _init = true; return raw; }
+        raw = ClampDelta(raw, _prev, maxDelta);
+        _prev = raw;
+        return raw;
+      }
+
+      public void Reset(Vector3 v) { _prev = v; _init = true; }
+    }
+
+    // 이전 구현: 이동평균 버퍼 + deadzone (미세 노이즈 무시, 큰 움직임만 반영)
+    private class MovingAverageFilter : IPositionFilter
+    {
+      private readonly int       _bufferSize;
+      private readonly float     _deadzone;
+      private readonly Vector3[] _buffer;
+      private int     _index;
+      private int     _count;
+      private Vector3 _filtered;
+      private bool    _init;
+
+      public MovingAverageFilter(int bufferSize, float deadzone)
+      {
+        _bufferSize = Mathf.Max(1, bufferSize);
+        _deadzone   = deadzone;
+        _buffer     = new Vector3[_bufferSize];
+      }
+
+      public Vector3 Update(Vector3 raw, float dt, Vector3 maxDelta)
+      {
+        if (_init) raw = ClampDelta(raw, _filtered, maxDelta);
+
+        _buffer[_index] = raw;
+        _index = (_index + 1) % _bufferSize;
+        if (_count < _bufferSize) _count++;
+
+        Vector3 avg = Vector3.zero;
+        for (int i = 0; i < _count; i++) avg += _buffer[i];
+        avg /= _count;
+
+        if (!_init || Vector3.Distance(avg, _filtered) > _deadzone)
+          _filtered = avg;
+
+        _init = true;
+        return _filtered;
+      }
+
+      public void Reset(Vector3 v)
+      {
+        for (int i = 0; i < _bufferSize; i++) _buffer[i] = v;
+        _count = _bufferSize; _index = 0; _filtered = v; _init = true;
+      }
+    }
+
+    // _prev 기준 ±maxDelta 클램프 (축별, float.MaxValue=비활성)
+    private static Vector3 ClampDelta(Vector3 raw, Vector3 prev, Vector3 maxDelta)
+    {
+      return new Vector3(
+        maxDelta.x >= float.MaxValue ? raw.x : Mathf.Clamp(raw.x, prev.x - maxDelta.x, prev.x + maxDelta.x),
+        maxDelta.y >= float.MaxValue ? raw.y : Mathf.Clamp(raw.y, prev.y - maxDelta.y, prev.y + maxDelta.y),
+        maxDelta.z >= float.MaxValue ? raw.z : Mathf.Clamp(raw.z, prev.z - maxDelta.z, prev.z + maxDelta.z));
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -87,7 +176,7 @@ namespace Demo.GestureDetection
       public void Reset(float value) { _prev = value; _dPrev = 0f; _initialized = true; }
     }
 
-    private class OneEuroFilter
+    private class OneEuroFilter : IPositionFilter
     {
       private readonly OneEuroFilter1D _x, _y, _z;
 
@@ -186,11 +275,25 @@ namespace Demo.GestureDetection
     [SerializeField] private Vector3 _leftHandOffset  = Vector3.zero;
     [SerializeField] private Vector3 _rightHandOffset = Vector3.zero;
 
+    [Header("Jitter Filter Mode (평가/비교용)")]
+    [Tooltip("떨림 보정 필터 선택. 같은 씬·동작에서 필터만 바꿔 비교 측정. 런타임 변경 즉시 반영")]
+    [SerializeField] private JitterFilterMode _filterMode = JitterFilterMode.OneEuro;
+    [Tooltip("이동평균 버퍼 크기 (MovingAverage 모드 전용). 클수록 부드럽지만 반응 느려짐 (권장: 3~6)")]
+    [SerializeField] private int _maBufferSize = 4;
+    [Tooltip("이 거리 이하 움직임 무시 (MovingAverage 모드 전용, Unity 월드 단위, 권장: 0.003~0.01)")]
+    [SerializeField] private float _maDeadzone = 0.005f;
+
     [Header("Jitter Filter Settings (One Euro Filter)")]
     [Tooltip("정지 시 필터 강도. 낮을수록 떨림 더 제거 (권장: 0.5~3.0)")]
     [SerializeField] private float _minCutoff = 1.0f;
     [Tooltip("속도 민감도. 높을수록 빠른 동작에 더 즉각 반응 (권장: 0.01~0.3)")]
     [SerializeField] private float _beta = 0.05f;
+
+    [Header("Metrics Recording (CSV, 평가용)")]
+    [Tooltip("체크하면 raw/필터 좌표를 매 프레임 기록, 해제하면 CSV 파일로 저장")]
+    [SerializeField] private bool _recordMetrics = false;
+    [Tooltip("기록 대상 손. 측정 시 해당 손을 가만히(떨림) 또는 좌우로(지연) 움직일 것")]
+    [SerializeField] private RecordJoint _recordJoint = RecordJoint.RightHand;
 
     [Header("Arm Outlier Rejection")]
     [Tooltip("프레임당 팔/팔꿈치 최대 이동량 (XYZ). Z를 작게 설정해 제스처 시 깊이 튐 방지. 0=비활성")]
@@ -227,11 +330,17 @@ namespace Demo.GestureDetection
     private bool  _hasCachedData  = false;
     private float _lastDataTime;
 
-    // 위치 필터
-    private OneEuroFilter _leftHandPosFilter;
-    private OneEuroFilter _rightHandPosFilter;
-    private OneEuroFilter _leftElbowPosFilter;
-    private OneEuroFilter _rightElbowPosFilter;
+    // 위치 필터 (런타임에 _filterMode로 교체 가능)
+    private IPositionFilter _leftHandPosFilter;
+    private IPositionFilter _rightHandPosFilter;
+    private IPositionFilter _leftElbowPosFilter;
+    private IPositionFilter _rightElbowPosFilter;
+    private JitterFilterMode _activeFilterMode;
+
+    // 메트릭 CSV 기록 상태
+    private List<string> _csvRows;
+    private bool         _wasRecording;
+    private float        _recordStartTime;
 
     // handedness 안정화
     private bool _lastIsHand0Left      = true;
@@ -307,11 +416,8 @@ namespace Demo.GestureDetection
       CacheFingerBones();
       InitializeFingerRotations();
 
-      // 필터 초기화
-      _leftHandPosFilter   = new OneEuroFilter(_minCutoff, _beta);
-      _rightHandPosFilter  = new OneEuroFilter(_minCutoff, _beta);
-      _leftElbowPosFilter  = new OneEuroFilter(_minCutoff, _beta);
-      _rightElbowPosFilter = new OneEuroFilter(_minCutoff, _beta);
+      // 필터 초기화 (_filterMode에 따라 생성)
+      RebuildFilters();
 
       // rest position/rotation 저장. 필터는 Reset하지 않고 _initialized=false 유지.
       // 첫 실제 데이터 프레임에서 outlier rejection 없이 즉시 그 위치로 초기화됨.
@@ -366,6 +472,12 @@ namespace Demo.GestureDetection
     // ─────────────────────────────────────────────────────────────────────────
     private void LateUpdate()
     {
+      // 필터 모드가 Inspector에서 바뀌면 즉시 재생성
+      if (_filterMode != _activeFilterMode) RebuildFilters();
+
+      // 기록 체크박스 on/off 엣지 처리 (on→버퍼 시작, off→CSV 저장)
+      HandleRecordingEdge();
+
       // lock으로 스냅샷을 안전하게 읽어옴 (메인 스레드에서만 사용)
       LandmarkSnapshot snap;
       bool hasNew;
@@ -534,8 +646,8 @@ namespace Demo.GestureDetection
       // 손목을 모을 때 pose Z 추정이 튀어 손이 카메라로 돌진 → 깊이 뻗음에 절대 한계 적용
       shoulderToWrist.z = Mathf.Clamp(shoulderToWrist.z, _handReachZClamp.x, _handReachZClamp.y);
 
-      OneEuroFilter handFilter  = isLeft ? _leftHandPosFilter  : _rightHandPosFilter;
-      OneEuroFilter elbowFilter = isLeft ? _leftElbowPosFilter : _rightElbowPosFilter;
+      IPositionFilter handFilter  = isLeft ? _leftHandPosFilter  : _rightHandPosFilter;
+      IPositionFilter elbowFilter = isLeft ? _leftElbowPosFilter : _rightElbowPosFilter;
 
       // 각 축 독립적으로 0이면 비활성 (float.MaxValue = 제한 없음)
       Vector3 maxJump = new Vector3(
@@ -543,8 +655,13 @@ namespace Demo.GestureDetection
         _maxArmJumpPerFrame.y > 0f ? _maxArmJumpPerFrame.y : float.MaxValue,
         _maxArmJumpPerFrame.z > 0f ? _maxArmJumpPerFrame.z : float.MaxValue);
       float smoothT = 1f - Mathf.Exp(-_smoothing * Time.deltaTime);
-      Vector3 filteredWrist = handFilter.Update(shoulderPos + shoulderToWrist, Time.deltaTime, maxJump);
+      Vector3 rawWrist      = shoulderPos + shoulderToWrist;
+      Vector3 filteredWrist = handFilter.Update(rawWrist, Time.deltaTime, maxJump);
       handTarget.position = Vector3.Lerp(handTarget.position, filteredWrist, smoothT);
+
+      // 평가용: 선택한 손의 raw(필터 입력) vs filtered(필터 출력) 기록
+      if (_recordMetrics && isLeft == (_recordJoint == RecordJoint.LeftHand))
+        RecordRow(rawWrist, filteredWrist);
 
       if (elbowHint != null)
       {
@@ -755,6 +872,91 @@ namespace Demo.GestureDetection
       if (_leftArmIK  != null) _leftArmIK.weight  = 0f;
       if (_rightArmIK != null) _rightArmIK.weight = 0f;
       if (_fingerLayerIndex >= 0) _animator.SetLayerWeight(_fingerLayerIndex, 1f);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 필터 종류 교체 (평가/비교용)
+    // ─────────────────────────────────────────────────────────────────────────
+    private IPositionFilter CreateFilter()
+    {
+      switch (_filterMode)
+      {
+        case JitterFilterMode.None:          return new NoFilter();
+        case JitterFilterMode.MovingAverage: return new MovingAverageFilter(_maBufferSize, _maDeadzone);
+        default:                             return new OneEuroFilter(_minCutoff, _beta);
+      }
+    }
+
+    private void RebuildFilters()
+    {
+      _leftHandPosFilter   = CreateFilter();
+      _rightHandPosFilter  = CreateFilter();
+      _leftElbowPosFilter  = CreateFilter();
+      _rightElbowPosFilter = CreateFilter();
+      _activeFilterMode    = _filterMode;
+      Debug.Log($"[GolemLandmarkAnimator] Filter mode = {_filterMode}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 메트릭 CSV 기록: _recordMetrics 체크 on→기록 시작, off→파일 저장
+    // 컬럼: time_s, dt_s, fps, filter_mode, raw_xyz, filt_xyz
+    //   떨림 = 손 정지 시 filt_xyz의 표준편차
+    //   지연 = 손 흔들 때 raw_xyz vs filt_xyz의 교차상관 offset
+    //   FPS  = fps 컬럼 평균
+    // ─────────────────────────────────────────────────────────────────────────
+    private void HandleRecordingEdge()
+    {
+      if (_recordMetrics && !_wasRecording)
+      {
+        _csvRows = new List<string>
+        {
+          "time_s,dt_s,fps,filter_mode,raw_x,raw_y,raw_z,filt_x,filt_y,filt_z"
+        };
+        _recordStartTime = Time.time;
+        Debug.Log($"[GestureMetrics] Recording START (mode={_filterMode}, joint={_recordJoint})");
+      }
+      else if (!_recordMetrics && _wasRecording)
+      {
+        WriteCsv();
+      }
+      _wasRecording = _recordMetrics;
+    }
+
+    private void RecordRow(Vector3 raw, Vector3 filtered)
+    {
+      if (_csvRows == null) return;
+      float dt  = Time.deltaTime;
+      float fps = dt > 0f ? 1f / dt : 0f;
+      var   c   = CultureInfo.InvariantCulture;
+      _csvRows.Add(string.Format(c,
+        "{0:F4},{1:F5},{2:F1},{3},{4:F5},{5:F5},{6:F5},{7:F5},{8:F5},{9:F5}",
+        Time.time - _recordStartTime, dt, fps, _filterMode,
+        raw.x, raw.y, raw.z, filtered.x, filtered.y, filtered.z));
+    }
+
+    private void WriteCsv()
+    {
+      if (_csvRows == null || _csvRows.Count <= 1)
+      {
+        Debug.LogWarning("[GestureMetrics] 기록된 데이터 없음 (손이 화면에 잡혔는지 확인)");
+        _csvRows = null;
+        return;
+      }
+
+      string dir = Path.Combine(Application.dataPath, "..", "GestureMetrics");
+      Directory.CreateDirectory(dir);
+      string file = Path.Combine(dir,
+        $"gesture_{_filterMode}_{_recordJoint}_{DateTime.Now:yyyyMMdd_HHmmss}.csv");
+      File.WriteAllLines(file, _csvRows);
+      Debug.Log($"[GestureMetrics] {_csvRows.Count - 1} rows 저장 → {Path.GetFullPath(file)}");
+      _csvRows = null;
+    }
+
+    private void OnDisable()
+    {
+      // 기록 중 플레이 종료/비활성 시 데이터 유실 방지
+      if (_wasRecording) WriteCsv();
+      _wasRecording = false;
     }
 
     private bool IsValidData(PoseLandmarkerResult poseResult, HandLandmarkerResult handResult)

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
@@ -199,6 +199,8 @@ namespace Demo.GestureDetection
     [Header("Arm Reach Settings")]
     [Tooltip("바디 스케일(어깨 너비) 기준으로 팔 뻗음을 정규화. 카메라 거리 무관하게 동일한 팔 움직임 보장")]
     [SerializeField] private bool _normalizeByBodyScale = true;
+    [Tooltip("어깨 기준 손 target의 Z(깊이) 뻗음 허용 범위 (min, max). 손목을 모을 때 pose 깊이 추정이 튀어 손이 카메라로 돌진/잘리는 현상 방지. 증폭 적용 후 값 기준.")]
+    [SerializeField] private Vector2 _handReachZClamp = new Vector2(-2f, 2f);
 
     [Header("Handedness Stability")]
     [Tooltip("MediaPipe 핸드니스 라벨이 이 프레임 수 이상 연속으로 바뀔 때만 좌우 할당 전환 (순간 flip 방지)")]
@@ -528,6 +530,9 @@ namespace Demo.GestureDetection
       shoulderToWrist.y *= _handAxisMultiplier.y;
       shoulderToWrist.z *= _handAxisMultiplier.z;
       shoulderToWrist   *= _handReachMultiplier;
+
+      // 손목을 모을 때 pose Z 추정이 튀어 손이 카메라로 돌진 → 깊이 뻗음에 절대 한계 적용
+      shoulderToWrist.z = Mathf.Clamp(shoulderToWrist.z, _handReachZClamp.x, _handReachZClamp.y);
 
       OneEuroFilter handFilter  = isLeft ? _leftHandPosFilter  : _rightHandPosFilter;
       OneEuroFilter elbowFilter = isLeft ? _leftElbowPosFilter : _rightElbowPosFilter;

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
@@ -1,6 +1,8 @@
-using System;
-using System.IO;
-using System.Globalization;
+#if GESTURE_METRICS
+using System;                 // DateTime (CSV 파일명)
+using System.IO;              // Path/File/Directory (CSV 저장)
+using System.Globalization;   // CultureInfo (CSV 숫자 포맷)
+#endif
 using UnityEngine;
 using UnityEngine.Animations.Rigging;
 using Mediapipe.Tasks.Vision.HandLandmarker;
@@ -289,11 +291,13 @@ namespace Demo.GestureDetection
     [Tooltip("속도 민감도. 높을수록 빠른 동작에 더 즉각 반응 (권장: 0.01~0.3)")]
     [SerializeField] private float _beta = 0.05f;
 
-    [Header("Metrics Recording (CSV, 평가용)")]
+#if GESTURE_METRICS
+    [Header("Metrics Recording (CSV, 평가용 — GESTURE_METRICS define 시에만 컴파일)")]
     [Tooltip("체크하면 raw/필터 좌표를 매 프레임 기록, 해제하면 CSV 파일로 저장")]
     [SerializeField] private bool _recordMetrics = false;
     [Tooltip("기록 대상 손. 측정 시 해당 손을 가만히(떨림) 또는 좌우로(지연) 움직일 것")]
     [SerializeField] private RecordJoint _recordJoint = RecordJoint.RightHand;
+#endif
 
     [Header("Arm Outlier Rejection")]
     [Tooltip("프레임당 팔/팔꿈치 최대 이동량 (XYZ). Z를 작게 설정해 제스처 시 깊이 튐 방지. 0=비활성")]
@@ -337,10 +341,12 @@ namespace Demo.GestureDetection
     private IPositionFilter _rightElbowPosFilter;
     private JitterFilterMode _activeFilterMode;
 
+#if GESTURE_METRICS
     // 메트릭 CSV 기록 상태
     private List<string> _csvRows;
     private bool         _wasRecording;
     private float        _recordStartTime;
+#endif
 
     // handedness 안정화
     private bool _lastIsHand0Left      = true;
@@ -475,8 +481,10 @@ namespace Demo.GestureDetection
       // 필터 모드가 Inspector에서 바뀌면 즉시 재생성
       if (_filterMode != _activeFilterMode) RebuildFilters();
 
+#if GESTURE_METRICS
       // 기록 체크박스 on/off 엣지 처리 (on→버퍼 시작, off→CSV 저장)
       HandleRecordingEdge();
+#endif
 
       // lock으로 스냅샷을 안전하게 읽어옴 (메인 스레드에서만 사용)
       LandmarkSnapshot snap;
@@ -659,9 +667,11 @@ namespace Demo.GestureDetection
       Vector3 filteredWrist = handFilter.Update(rawWrist, Time.deltaTime, maxJump);
       handTarget.position = Vector3.Lerp(handTarget.position, filteredWrist, smoothT);
 
+#if GESTURE_METRICS
       // 평가용: 선택한 손의 raw(필터 입력) vs filtered(필터 출력) 기록
       if (_recordMetrics && isLeft == (_recordJoint == RecordJoint.LeftHand))
         RecordRow(rawWrist, filteredWrist);
+#endif
 
       if (elbowHint != null)
       {
@@ -897,6 +907,7 @@ namespace Demo.GestureDetection
       Debug.Log($"[GolemLandmarkAnimator] Filter mode = {_filterMode}");
     }
 
+#if GESTURE_METRICS
     // ─────────────────────────────────────────────────────────────────────────
     // 메트릭 CSV 기록: _recordMetrics 체크 on→기록 시작, off→파일 저장
     // 컬럼: time_s, dt_s, fps, filter_mode, raw_xyz, filt_xyz
@@ -958,6 +969,7 @@ namespace Demo.GestureDetection
       if (_wasRecording) WriteCsv();
       _wasRecording = false;
     }
+#endif
 
     private bool IsValidData(PoseLandmarkerResult poseResult, HandLandmarkerResult handResult)
     {

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureRecognizer.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureRecognizer.cs
@@ -104,9 +104,11 @@ namespace Demo.GestureDetection
         {
           // confidence 계산: 프레임 카운트 기반
           float confidence = Mathf.Min(1f, _gestureFrameCount[_currentGestureType] / (float)_holdFrames);
-          
-          Debug.Log($"[GestureRecognizer] {_currentGestureType} detected! Count={_gestureFrameCount[_currentGestureType]}, Confidence={confidence:F2}");
-          
+
+          // holdFrames 도달 첫 프레임에만 로그 (매 프레임 출력 방지)
+          if (_gestureFrameCount[_currentGestureType] == _holdFrames)
+            Debug.Log($"[GestureRecognizer] {_currentGestureType} detected! Count={_gestureFrameCount[_currentGestureType]}, Confidence={confidence:F2}");
+
           return new GestureResult(_currentGestureType, confidence, true, rawResult.Direction);
         }
       }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GesturePlayView.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GesturePlayView.cs
@@ -63,10 +63,12 @@ namespace Demo.GestureDetection.UI
     /// </summary>
     public void UpdateDisplay(DisplayData data)
     {
-      // 1. 데이터 유효성에 따른 Avatar 업데이트
+      // 1. 데이터 유효성 체크
       if (!data.HasValidData)
       {
-        ResetAvatar();
+        // ResetAvatar() 호출 안 함: 두 손이 가까워 한쪽이 잠깐 미검출될 때마다
+        // IK weight가 0으로 즉시 스냅되어 팔이 깜빡인다. GolemLandmarkAnimator의
+        // _dataTimeout(1초) + ReturnTargetsToRest()가 데이터 끊김을 부드럽게 처리한다.
         UpdateHoldProgressBar(0f, false);
         return;
       }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GestureUIController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GestureUIController.cs
@@ -62,20 +62,14 @@ namespace Demo.GestureDetection.UI
     /// </summary>
     public void UpdateGestureResult(GestureResult result)
     {
-      // 타겟 제스처만 반응
-      if (result.Type == _targetGesture && result.IsDetected)
-      {
-        _isActive = true;
+      bool wasActive = _isActive;
+
+      // Recognizer는 활성 전략 하나만 평가 → result.Type은 타겟 또는 None
+      _isActive = result.Type == _targetGesture && result.IsDetected;
+
+      // 비활성 → 활성 전환 시에만 로그 (매 프레임 출력 방지)
+      if (_isActive && !wasActive)
         Debug.Log($"[GestureUIController] {_targetGesture} detected - activating indicator");
-      }
-      else
-      {
-        _isActive = false;
-        if (result.Type != GestureType.None)
-        {
-          Debug.Log($"[GestureUIController] Detected {result.Type}, but target is {_targetGesture}");
-        }
-      }
     }
 
     /// <summary>

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Systems/Interactions/Scripts/ForestAfternoonController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Systems/Interactions/Scripts/ForestAfternoonController.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.SceneManagement;
@@ -68,11 +69,30 @@ public class ForestAfternoonController : MonoBehaviour
         requestStartDialogueEvent?.Raise("DLG-012");
     }
 
-    // DLG-012 완료 → 씬 전환
+    // DLG-012 완료 → 타임라인 종료까지 대기 후 씬 전환
     private void OnDialogueCompleted()
     {
         if (!_waitingForDialogueComplete) return;
         _waitingForDialogueComplete = false;
+        StartCoroutine(LoadNextSceneAfterTimeline());
+    }
+
+    /// <summary>
+    /// Yarn 대화가 끝나도 컷씬 Timeline이 끝까지 재생될 때까지 대기한 뒤 씬을 전환한다.
+    /// extrapolationMode = Hold라 타임라인이 끝나도 stopped 이벤트가 발생하지 않으므로
+    /// time이 duration에 도달했는지로 종료를 판정한다.
+    /// </summary>
+    private IEnumerator LoadNextSceneAfterTimeline()
+    {
+        if (cutsceneDirector != null)
+        {
+            while (cutsceneDirector.state == PlayState.Playing &&
+                   cutsceneDirector.time < cutsceneDirector.duration)
+            {
+                yield return null;
+            }
+        }
+
         SceneManager.LoadScene(nextScene);
     }
 


### PR DESCRIPTION
## Summary

제스처 손 떨림 보정 필터(One Euro vs. Moving Average vs. None)를 런타임에 교체하고 raw/filtered 좌표를 CSV로 기록해 정량 비교할 수 있는 평가 하네스 추가.
메트릭 기록 코드는 `GESTURE_METRICS` define 뒤에 격리되어 있어 빌드 기본값에서는 완전히 컴파일 제외됨.

## Changes

**`GolemLandmarkAnimator.cs`**

- `IPositionFilter` 인터페이스 도입 → `OneEuroFilter`, `MovingAverageFilter`, `NoFilter` 공통 추상화
- `JitterFilterMode` enum (`None` / `MovingAverage` / `OneEuro`) 추가, Inspector에서 런타임 교체 즉시 반영 (`RebuildFilters`)
- `MovingAverageFilter` 구현 (이동평균 버퍼 + deadzone): 이전 구현 방식과 비교용
- `ClampDelta` 헬퍼 분리: 이상치 제거 로직을 세 필터 모드 공통으로 적용
- 메트릭 CSV 기록 기능 (`#if GESTURE_METRICS`로 격리):
  - `_recordMetrics` 체크 on → 기록 시작, off → `GestureMetrics/` 폴더에 CSV 저장
  - 컬럼: `time_s, dt_s, fps, filter_mode, raw_xyz, filt_xyz`
  - 떨림 측정: 손 정지 시 `filt_xyz` 표준편차
  - 지연 측정: 손 흔들 시 `raw_xyz` vs `filt_xyz` 교차상관 offset
  - 플레이 종료/비활성 시 `OnDisable`에서 자동 저장
- `System`, `System.IO`, `System.Globalization` using 문도 `#if GESTURE_METRICS`로 격리 (일반 빌드 의존성 제거)

## How to enable metrics recording

Player Settings → **Scripting Define Symbols** 에 `GESTURE_METRICS` 추가 후 빌드.
측정 완료 후 define 제거하면 관련 코드 전체 컴파일 제외.