### PR TITLE
Feat/gesture fail retry or skip

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
@@ -8846,11 +8846,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _minCutoff
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _positionDeadzone
       value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _handReachZClamp.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _handReachZClamp.y
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _handReachMultiplier
@@ -8874,7 +8882,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _maxArmJumpPerFrame.z
-      value: 0.15
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
+      propertyPath: _normalizeByBodyScale
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _handRotationSmoothing

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
@@ -225,6 +225,127 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &32933326
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 32933327}
+  - component: {fileID: 32933330}
+  - component: {fileID: 32933329}
+  - component: {fileID: 32933328}
+  m_Layer: 5
+  m_Name: Skip Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &32933327
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 32933326}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 256944380}
+  m_Father: {fileID: 1256679742}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 150, y: -100}
+  m_SizeDelta: {x: 200, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &32933328
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 32933326}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.5597484, g: 0.5597484, b: 0.5597484, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 32933329}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &32933329
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 32933326}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2b62f169ad6c04c2d9a3fa4e8c3aa694, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &32933330
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 32933326}
+  m_CullTransparentMesh: 1
 --- !u!1 &50850779 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7483966810414094594, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
@@ -1182,6 +1303,142 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &256944379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 256944380}
+  - component: {fileID: 256944382}
+  - component: {fileID: 256944381}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &256944380
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256944379}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 32933327}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &256944381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256944379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uB118\uC5B4\uAC00\uAE30"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 3f5c05ef14383452c99a018a291744a7, type: 2}
+  m_sharedMaterial: {fileID: -6193203460992081240, guid: 3f5c05ef14383452c99a018a291744a7, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &256944382
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256944379}
+  m_CullTransparentMesh: 1
 --- !u!1001 &262898558
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1425,6 +1682,142 @@ Transform:
   - {fileID: 763645885}
   m_Father: {fileID: 215058542}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &277340301
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 277340302}
+  - component: {fileID: 277340304}
+  - component: {fileID: 277340303}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &277340302
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 277340301}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1465251207}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &277340303
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 277340301}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uB2E4\uC2DC\uD574\uBCF4\uAE30"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 3f5c05ef14383452c99a018a291744a7, type: 2}
+  m_sharedMaterial: {fileID: -6193203460992081240, guid: 3f5c05ef14383452c99a018a291744a7, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &277340304
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 277340301}
+  m_CullTransparentMesh: 1
 --- !u!1 &292408355
 GameObject:
   m_ObjectHideFlags: 0
@@ -6026,6 +6419,84 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1198557888}
   m_CullTransparentMesh: 1
+--- !u!1 &1256679741
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1256679742}
+  - component: {fileID: 1256679744}
+  - component: {fileID: 1256679743}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1256679742
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1256679741}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1747299942}
+  - {fileID: 1465251207}
+  - {fileID: 32933327}
+  m_Father: {fileID: 1486643008}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1256679743
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1256679741}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.29803923}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1256679744
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1256679741}
+  m_CullTransparentMesh: 1
 --- !u!1 &1266644734
 GameObject:
   m_ObjectHideFlags: 0
@@ -6798,6 +7269,127 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1459076828}
   m_CullTransparentMesh: 1
+--- !u!1 &1465251206
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1465251207}
+  - component: {fileID: 1465251210}
+  - component: {fileID: 1465251209}
+  - component: {fileID: 1465251208}
+  m_Layer: 5
+  m_Name: Retry Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1465251207
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465251206}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 277340302}
+  m_Father: {fileID: 1256679742}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -150, y: -100}
+  m_SizeDelta: {x: 200, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1465251208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465251206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.57861626, g: 0.57861626, b: 0.57861626, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1465251209}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1465251209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465251206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2b62f169ad6c04c2d9a3fa4e8c3aa694, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1465251210
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465251206}
+  m_CullTransparentMesh: 1
 --- !u!1 &1479458216
 GameObject:
   m_ObjectHideFlags: 0
@@ -6873,6 +7465,108 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 10
   m_TargetDisplay: 0
+--- !u!1 &1486643004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1486643008}
+  - component: {fileID: 1486643007}
+  - component: {fileID: 1486643006}
+  - component: {fileID: 1486643005}
+  m_Layer: 5
+  m_Name: Retry Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1486643005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486643004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1486643006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486643004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0.5
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1486643007
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486643004}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1486643008
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486643004}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1256679742}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1001 &1542106540
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7001,6 +7695,142 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &1573427431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1573427432}
+  - component: {fileID: 1573427434}
+  - component: {fileID: 1573427433}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1573427432
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1573427431}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1747299942}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1000, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1573427433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1573427431}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uD53C\uB4DC\uBC31 \uD14D\uC2A4\uD2B8"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 3f5c05ef14383452c99a018a291744a7, type: 2}
+  m_sharedMaterial: {fileID: -6193203460992081240, guid: 3f5c05ef14383452c99a018a291744a7, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1573427434
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1573427431}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1575411499
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7363,6 +8193,82 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &1747299941
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1747299942}
+  - component: {fileID: 1747299944}
+  - component: {fileID: 1747299943}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1747299942
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1747299941}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1573427432}
+  m_Father: {fileID: 1256679742}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 80}
+  m_SizeDelta: {x: 1000, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1747299943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1747299941}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2b62f169ad6c04c2d9a3fa4e8c3aa694, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1747299944
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1747299941}
+  m_CullTransparentMesh: 1
 --- !u!1 &1755505738 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 207745087118991948, guid: e656699b143494148a872961a9feb410, type: 3}
@@ -7823,6 +8729,28 @@ MonoBehaviour:
   _debounceDuration: 0.2
   _requiredHoldDuration: 5
   _progressShowThreshold: 2
+  _noHandTimeout: 7
+  _holdFailTimeout: 25
+  _failOverlay: {fileID: 1256679741}
+  _failReasonText: {fileID: 1573427433}
+  _retryButton: {fileID: 1465251208}
+  _failSkipButton: {fileID: 32933328}
+  _msgNoHands: "\uC591\uC190\uC774 \uCE74\uBA54\uB77C\uC5D0 \uC798 \uBCF4\uC774\uB3C4\uB85D
+    \uC704\uCE58\uB97C \uC870\uC815\uD574 \uC8FC\uC138\uC694."
+  _msgPoseMissing: "\uBAB8 \uC804\uCCB4\uAC00 \uBCF4\uC774\uB3C4\uB85D \uCE74\uBA54\uB77C\uC5D0\uC11C
+    \uC870\uAE08 \uBB3C\uB7EC\uB098 \uC8FC\uC138\uC694."
+  _msgHandMissing: "\uC190\uC774 \uD654\uBA74 \uBC16\uC73C\uB85C \uBC97\uC5B4\uB098\uC9C0
+    \uC54A\uAC8C \uC720\uC9C0\uD574 \uC8FC\uC138\uC694."
+  _msgPalmsNotForward: "\uC190\uBC14\uB2E5\uC774 \uCE74\uBA54\uB77C\uB97C \uD5A5\uD558\uB3C4\uB85D
+    \uD3B4 \uC8FC\uC138\uC694."
+  _msgHandsNotOpposite: "\uC190\uBAA9\uB07C\uB9AC \uB2FF\uB3C4\uB85D \uC190\uC744
+    \uD3BC\uCCD0\uC8FC\uC138\uC694."
+  _msgWristsTooFar: "\uB450 \uC190\uC744 \uB354 \uAC00\uAE4C\uC774 \uBAA8\uC544 \uC8FC\uC138\uC694."
+  _msgFingersNotOpen: "\uC190\uAC00\uB77D\uC744 \uCAD9 \uD3B4 \uC8FC\uC138\uC694."
+  _msgNotRising: "\uB450 \uD314\uC744 \uC704\uB85C \uCB49 \uB4E4\uC5B4\uC62C\uB824
+    \uC8FC\uC138\uC694."
+  _msgGeneric: "\uD29C\uD1A0\uB9AC\uC5BC\uC758 \uC790\uC138\uB97C \uCC9C\uCC9C\uD788
+    \uB530\uB77C \uD574 \uBCF4\uC138\uC694."
   _objectiveID_NoFly: MQ-02-OBJ-02
   _objectiveID_Fly: MQ-02-OBJ-04
   _requestCompletePhaseEvent: {fileID: 11400000, guid: e2da95cd4a1d545b1b66af5c47cc8d21, type: 2}
@@ -9249,3 +10177,4 @@ SceneRoots:
   - {fileID: 1554780055}
   - {fileID: 1742802889}
   - {fileID: 671093180}
+  - {fileID: 1486643008}

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
@@ -907,6 +907,7 @@ MonoBehaviour:
   letterDesk: {fileID: 112640438}
   bedInteraction: {fileID: 987776660}
   exitDoor: {fileID: 520658544}
+  letterReadPresenter: {fileID: 2025068436}
   enableDebugLogs: 1
 --- !u!4 &339390117
 Transform:

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Room.unity
@@ -8904,7 +8904,7 @@ RectTransform:
   m_Father: {fileID: 390805422104622915}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -11952,7 +11952,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2927166725123618203}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1427368679984008097}
+        m_TargetAssemblyTypeName: SettingsPresenter, Assembly-CSharp
+        m_MethodName: ResetAllDataAndGoHome
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &5670413968197503670
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12118,7 +12130,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &5885309875298852337
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12725,7 +12737,7 @@ RectTransform:
   m_Father: {fileID: 943481579840445490}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Globalization;
 using UnityEngine;
 using UnityEngine.Animations.Rigging;
 using Mediapipe.Tasks.Vision.HandLandmarker;
@@ -19,6 +22,12 @@ namespace Demo.GestureDetection
   /// </summary>
   public class GolemLandmarkAnimator : MonoBehaviour
   {
+    // 떨림 보정 필터 종류 (평가/비교 측정용)
+    public enum JitterFilterMode { None, MovingAverage, OneEuro }
+
+    // CSV로 기록할 손 (golem 기준 좌/우 hand target)
+    public enum RecordJoint { RightHand, LeftHand }
+
     // ─────────────────────────────────────────────────────────────────────────
     // 스레드 안전 스냅샷
     // MediaPipe 콜백은 백그라운드 스레드에서 실행.
@@ -33,6 +42,86 @@ namespace Demo.GestureDetection
       public Vector3[] hand1;      // Hand 1 landmarks [0..20]
       public string    hand0Label; // "Left" or "Right" (MediaPipe 기준)
       public bool      valid;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 위치 필터 공통 인터페이스 (런타임에 종류 교체 → 평가 비교)
+    // maxDelta(이상치 제거)는 세 모드 모두 동일 적용 → 스무딩 거동만 비교됨
+    // ─────────────────────────────────────────────────────────────────────────
+    private interface IPositionFilter
+    {
+      Vector3 Update(Vector3 raw, float dt, Vector3 maxDelta);
+      void Reset(Vector3 v);
+    }
+
+    // 스무딩 없음: 이상치 클램프만 적용 (필터 off 기준선)
+    private class NoFilter : IPositionFilter
+    {
+      private Vector3 _prev;
+      private bool    _init;
+
+      public Vector3 Update(Vector3 raw, float dt, Vector3 maxDelta)
+      {
+        if (!_init) { _prev = raw; _init = true; return raw; }
+        raw = ClampDelta(raw, _prev, maxDelta);
+        _prev = raw;
+        return raw;
+      }
+
+      public void Reset(Vector3 v) { _prev = v; _init = true; }
+    }
+
+    // 이전 구현: 이동평균 버퍼 + deadzone (미세 노이즈 무시, 큰 움직임만 반영)
+    private class MovingAverageFilter : IPositionFilter
+    {
+      private readonly int       _bufferSize;
+      private readonly float     _deadzone;
+      private readonly Vector3[] _buffer;
+      private int     _index;
+      private int     _count;
+      private Vector3 _filtered;
+      private bool    _init;
+
+      public MovingAverageFilter(int bufferSize, float deadzone)
+      {
+        _bufferSize = Mathf.Max(1, bufferSize);
+        _deadzone   = deadzone;
+        _buffer     = new Vector3[_bufferSize];
+      }
+
+      public Vector3 Update(Vector3 raw, float dt, Vector3 maxDelta)
+      {
+        if (_init) raw = ClampDelta(raw, _filtered, maxDelta);
+
+        _buffer[_index] = raw;
+        _index = (_index + 1) % _bufferSize;
+        if (_count < _bufferSize) _count++;
+
+        Vector3 avg = Vector3.zero;
+        for (int i = 0; i < _count; i++) avg += _buffer[i];
+        avg /= _count;
+
+        if (!_init || Vector3.Distance(avg, _filtered) > _deadzone)
+          _filtered = avg;
+
+        _init = true;
+        return _filtered;
+      }
+
+      public void Reset(Vector3 v)
+      {
+        for (int i = 0; i < _bufferSize; i++) _buffer[i] = v;
+        _count = _bufferSize; _index = 0; _filtered = v; _init = true;
+      }
+    }
+
+    // _prev 기준 ±maxDelta 클램프 (축별, float.MaxValue=비활성)
+    private static Vector3 ClampDelta(Vector3 raw, Vector3 prev, Vector3 maxDelta)
+    {
+      return new Vector3(
+        maxDelta.x >= float.MaxValue ? raw.x : Mathf.Clamp(raw.x, prev.x - maxDelta.x, prev.x + maxDelta.x),
+        maxDelta.y >= float.MaxValue ? raw.y : Mathf.Clamp(raw.y, prev.y - maxDelta.y, prev.y + maxDelta.y),
+        maxDelta.z >= float.MaxValue ? raw.z : Mathf.Clamp(raw.z, prev.z - maxDelta.z, prev.z + maxDelta.z));
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -87,7 +176,7 @@ namespace Demo.GestureDetection
       public void Reset(float value) { _prev = value; _dPrev = 0f; _initialized = true; }
     }
 
-    private class OneEuroFilter
+    private class OneEuroFilter : IPositionFilter
     {
       private readonly OneEuroFilter1D _x, _y, _z;
 
@@ -186,11 +275,25 @@ namespace Demo.GestureDetection
     [SerializeField] private Vector3 _leftHandOffset  = Vector3.zero;
     [SerializeField] private Vector3 _rightHandOffset = Vector3.zero;
 
+    [Header("Jitter Filter Mode (평가/비교용)")]
+    [Tooltip("떨림 보정 필터 선택. 같은 씬·동작에서 필터만 바꿔 비교 측정. 런타임 변경 즉시 반영")]
+    [SerializeField] private JitterFilterMode _filterMode = JitterFilterMode.OneEuro;
+    [Tooltip("이동평균 버퍼 크기 (MovingAverage 모드 전용). 클수록 부드럽지만 반응 느려짐 (권장: 3~6)")]
+    [SerializeField] private int _maBufferSize = 4;
+    [Tooltip("이 거리 이하 움직임 무시 (MovingAverage 모드 전용, Unity 월드 단위, 권장: 0.003~0.01)")]
+    [SerializeField] private float _maDeadzone = 0.005f;
+
     [Header("Jitter Filter Settings (One Euro Filter)")]
     [Tooltip("정지 시 필터 강도. 낮을수록 떨림 더 제거 (권장: 0.5~3.0)")]
     [SerializeField] private float _minCutoff = 1.0f;
     [Tooltip("속도 민감도. 높을수록 빠른 동작에 더 즉각 반응 (권장: 0.01~0.3)")]
     [SerializeField] private float _beta = 0.05f;
+
+    [Header("Metrics Recording (CSV, 평가용)")]
+    [Tooltip("체크하면 raw/필터 좌표를 매 프레임 기록, 해제하면 CSV 파일로 저장")]
+    [SerializeField] private bool _recordMetrics = false;
+    [Tooltip("기록 대상 손. 측정 시 해당 손을 가만히(떨림) 또는 좌우로(지연) 움직일 것")]
+    [SerializeField] private RecordJoint _recordJoint = RecordJoint.RightHand;
 
     [Header("Arm Outlier Rejection")]
     [Tooltip("프레임당 팔/팔꿈치 최대 이동량 (XYZ). Z를 작게 설정해 제스처 시 깊이 튐 방지. 0=비활성")]
@@ -227,11 +330,17 @@ namespace Demo.GestureDetection
     private bool  _hasCachedData  = false;
     private float _lastDataTime;
 
-    // 위치 필터
-    private OneEuroFilter _leftHandPosFilter;
-    private OneEuroFilter _rightHandPosFilter;
-    private OneEuroFilter _leftElbowPosFilter;
-    private OneEuroFilter _rightElbowPosFilter;
+    // 위치 필터 (런타임에 _filterMode로 교체 가능)
+    private IPositionFilter _leftHandPosFilter;
+    private IPositionFilter _rightHandPosFilter;
+    private IPositionFilter _leftElbowPosFilter;
+    private IPositionFilter _rightElbowPosFilter;
+    private JitterFilterMode _activeFilterMode;
+
+    // 메트릭 CSV 기록 상태
+    private List<string> _csvRows;
+    private bool         _wasRecording;
+    private float        _recordStartTime;
 
     // handedness 안정화
     private bool _lastIsHand0Left      = true;
@@ -307,11 +416,8 @@ namespace Demo.GestureDetection
       CacheFingerBones();
       InitializeFingerRotations();
 
-      // 필터 초기화
-      _leftHandPosFilter   = new OneEuroFilter(_minCutoff, _beta);
-      _rightHandPosFilter  = new OneEuroFilter(_minCutoff, _beta);
-      _leftElbowPosFilter  = new OneEuroFilter(_minCutoff, _beta);
-      _rightElbowPosFilter = new OneEuroFilter(_minCutoff, _beta);
+      // 필터 초기화 (_filterMode에 따라 생성)
+      RebuildFilters();
 
       // rest position/rotation 저장. 필터는 Reset하지 않고 _initialized=false 유지.
       // 첫 실제 데이터 프레임에서 outlier rejection 없이 즉시 그 위치로 초기화됨.
@@ -366,6 +472,12 @@ namespace Demo.GestureDetection
     // ─────────────────────────────────────────────────────────────────────────
     private void LateUpdate()
     {
+      // 필터 모드가 Inspector에서 바뀌면 즉시 재생성
+      if (_filterMode != _activeFilterMode) RebuildFilters();
+
+      // 기록 체크박스 on/off 엣지 처리 (on→버퍼 시작, off→CSV 저장)
+      HandleRecordingEdge();
+
       // lock으로 스냅샷을 안전하게 읽어옴 (메인 스레드에서만 사용)
       LandmarkSnapshot snap;
       bool hasNew;
@@ -534,8 +646,8 @@ namespace Demo.GestureDetection
       // 손목을 모을 때 pose Z 추정이 튀어 손이 카메라로 돌진 → 깊이 뻗음에 절대 한계 적용
       shoulderToWrist.z = Mathf.Clamp(shoulderToWrist.z, _handReachZClamp.x, _handReachZClamp.y);
 
-      OneEuroFilter handFilter  = isLeft ? _leftHandPosFilter  : _rightHandPosFilter;
-      OneEuroFilter elbowFilter = isLeft ? _leftElbowPosFilter : _rightElbowPosFilter;
+      IPositionFilter handFilter  = isLeft ? _leftHandPosFilter  : _rightHandPosFilter;
+      IPositionFilter elbowFilter = isLeft ? _leftElbowPosFilter : _rightElbowPosFilter;
 
       // 각 축 독립적으로 0이면 비활성 (float.MaxValue = 제한 없음)
       Vector3 maxJump = new Vector3(
@@ -543,8 +655,13 @@ namespace Demo.GestureDetection
         _maxArmJumpPerFrame.y > 0f ? _maxArmJumpPerFrame.y : float.MaxValue,
         _maxArmJumpPerFrame.z > 0f ? _maxArmJumpPerFrame.z : float.MaxValue);
       float smoothT = 1f - Mathf.Exp(-_smoothing * Time.deltaTime);
-      Vector3 filteredWrist = handFilter.Update(shoulderPos + shoulderToWrist, Time.deltaTime, maxJump);
+      Vector3 rawWrist      = shoulderPos + shoulderToWrist;
+      Vector3 filteredWrist = handFilter.Update(rawWrist, Time.deltaTime, maxJump);
       handTarget.position = Vector3.Lerp(handTarget.position, filteredWrist, smoothT);
+
+      // 평가용: 선택한 손의 raw(필터 입력) vs filtered(필터 출력) 기록
+      if (_recordMetrics && isLeft == (_recordJoint == RecordJoint.LeftHand))
+        RecordRow(rawWrist, filteredWrist);
 
       if (elbowHint != null)
       {
@@ -755,6 +872,91 @@ namespace Demo.GestureDetection
       if (_leftArmIK  != null) _leftArmIK.weight  = 0f;
       if (_rightArmIK != null) _rightArmIK.weight = 0f;
       if (_fingerLayerIndex >= 0) _animator.SetLayerWeight(_fingerLayerIndex, 1f);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 필터 종류 교체 (평가/비교용)
+    // ─────────────────────────────────────────────────────────────────────────
+    private IPositionFilter CreateFilter()
+    {
+      switch (_filterMode)
+      {
+        case JitterFilterMode.None:          return new NoFilter();
+        case JitterFilterMode.MovingAverage: return new MovingAverageFilter(_maBufferSize, _maDeadzone);
+        default:                             return new OneEuroFilter(_minCutoff, _beta);
+      }
+    }
+
+    private void RebuildFilters()
+    {
+      _leftHandPosFilter   = CreateFilter();
+      _rightHandPosFilter  = CreateFilter();
+      _leftElbowPosFilter  = CreateFilter();
+      _rightElbowPosFilter = CreateFilter();
+      _activeFilterMode    = _filterMode;
+      Debug.Log($"[GolemLandmarkAnimator] Filter mode = {_filterMode}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 메트릭 CSV 기록: _recordMetrics 체크 on→기록 시작, off→파일 저장
+    // 컬럼: time_s, dt_s, fps, filter_mode, raw_xyz, filt_xyz
+    //   떨림 = 손 정지 시 filt_xyz의 표준편차
+    //   지연 = 손 흔들 때 raw_xyz vs filt_xyz의 교차상관 offset
+    //   FPS  = fps 컬럼 평균
+    // ─────────────────────────────────────────────────────────────────────────
+    private void HandleRecordingEdge()
+    {
+      if (_recordMetrics && !_wasRecording)
+      {
+        _csvRows = new List<string>
+        {
+          "time_s,dt_s,fps,filter_mode,raw_x,raw_y,raw_z,filt_x,filt_y,filt_z"
+        };
+        _recordStartTime = Time.time;
+        Debug.Log($"[GestureMetrics] Recording START (mode={_filterMode}, joint={_recordJoint})");
+      }
+      else if (!_recordMetrics && _wasRecording)
+      {
+        WriteCsv();
+      }
+      _wasRecording = _recordMetrics;
+    }
+
+    private void RecordRow(Vector3 raw, Vector3 filtered)
+    {
+      if (_csvRows == null) return;
+      float dt  = Time.deltaTime;
+      float fps = dt > 0f ? 1f / dt : 0f;
+      var   c   = CultureInfo.InvariantCulture;
+      _csvRows.Add(string.Format(c,
+        "{0:F4},{1:F5},{2:F1},{3},{4:F5},{5:F5},{6:F5},{7:F5},{8:F5},{9:F5}",
+        Time.time - _recordStartTime, dt, fps, _filterMode,
+        raw.x, raw.y, raw.z, filtered.x, filtered.y, filtered.z));
+    }
+
+    private void WriteCsv()
+    {
+      if (_csvRows == null || _csvRows.Count <= 1)
+      {
+        Debug.LogWarning("[GestureMetrics] 기록된 데이터 없음 (손이 화면에 잡혔는지 확인)");
+        _csvRows = null;
+        return;
+      }
+
+      string dir = Path.Combine(Application.dataPath, "..", "GestureMetrics");
+      Directory.CreateDirectory(dir);
+      string file = Path.Combine(dir,
+        $"gesture_{_filterMode}_{_recordJoint}_{DateTime.Now:yyyyMMdd_HHmmss}.csv");
+      File.WriteAllLines(file, _csvRows);
+      Debug.Log($"[GestureMetrics] {_csvRows.Count - 1} rows 저장 → {Path.GetFullPath(file)}");
+      _csvRows = null;
+    }
+
+    private void OnDisable()
+    {
+      // 기록 중 플레이 종료/비활성 시 데이터 유실 방지
+      if (_wasRecording) WriteCsv();
+      _wasRecording = false;
     }
 
     private bool IsValidData(PoseLandmarkerResult poseResult, HandLandmarkerResult handResult)

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
@@ -199,6 +199,8 @@ namespace Demo.GestureDetection
     [Header("Arm Reach Settings")]
     [Tooltip("바디 스케일(어깨 너비) 기준으로 팔 뻗음을 정규화. 카메라 거리 무관하게 동일한 팔 움직임 보장")]
     [SerializeField] private bool _normalizeByBodyScale = true;
+    [Tooltip("어깨 기준 손 target의 Z(깊이) 뻗음 허용 범위 (min, max). 손목을 모을 때 pose 깊이 추정이 튀어 손이 카메라로 돌진/잘리는 현상 방지. 증폭 적용 후 값 기준.")]
+    [SerializeField] private Vector2 _handReachZClamp = new Vector2(-2f, 2f);
 
     [Header("Handedness Stability")]
     [Tooltip("MediaPipe 핸드니스 라벨이 이 프레임 수 이상 연속으로 바뀔 때만 좌우 할당 전환 (순간 flip 방지)")]
@@ -528,6 +530,9 @@ namespace Demo.GestureDetection
       shoulderToWrist.y *= _handAxisMultiplier.y;
       shoulderToWrist.z *= _handAxisMultiplier.z;
       shoulderToWrist   *= _handReachMultiplier;
+
+      // 손목을 모을 때 pose Z 추정이 튀어 손이 카메라로 돌진 → 깊이 뻗음에 절대 한계 적용
+      shoulderToWrist.z = Mathf.Clamp(shoulderToWrist.z, _handReachZClamp.x, _handReachZClamp.y);
 
       OneEuroFilter handFilter  = isLeft ? _leftHandPosFilter  : _rightHandPosFilter;
       OneEuroFilter elbowFilter = isLeft ? _leftElbowPosFilter : _rightElbowPosFilter;

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
@@ -1,6 +1,8 @@
-using System;
-using System.IO;
-using System.Globalization;
+#if GESTURE_METRICS
+using System;                 // DateTime (CSV 파일명)
+using System.IO;              // Path/File/Directory (CSV 저장)
+using System.Globalization;   // CultureInfo (CSV 숫자 포맷)
+#endif
 using UnityEngine;
 using UnityEngine.Animations.Rigging;
 using Mediapipe.Tasks.Vision.HandLandmarker;
@@ -289,11 +291,13 @@ namespace Demo.GestureDetection
     [Tooltip("속도 민감도. 높을수록 빠른 동작에 더 즉각 반응 (권장: 0.01~0.3)")]
     [SerializeField] private float _beta = 0.05f;
 
-    [Header("Metrics Recording (CSV, 평가용)")]
+#if GESTURE_METRICS
+    [Header("Metrics Recording (CSV, 평가용 — GESTURE_METRICS define 시에만 컴파일)")]
     [Tooltip("체크하면 raw/필터 좌표를 매 프레임 기록, 해제하면 CSV 파일로 저장")]
     [SerializeField] private bool _recordMetrics = false;
     [Tooltip("기록 대상 손. 측정 시 해당 손을 가만히(떨림) 또는 좌우로(지연) 움직일 것")]
     [SerializeField] private RecordJoint _recordJoint = RecordJoint.RightHand;
+#endif
 
     [Header("Arm Outlier Rejection")]
     [Tooltip("프레임당 팔/팔꿈치 최대 이동량 (XYZ). Z를 작게 설정해 제스처 시 깊이 튐 방지. 0=비활성")]
@@ -337,10 +341,12 @@ namespace Demo.GestureDetection
     private IPositionFilter _rightElbowPosFilter;
     private JitterFilterMode _activeFilterMode;
 
+#if GESTURE_METRICS
     // 메트릭 CSV 기록 상태
     private List<string> _csvRows;
     private bool         _wasRecording;
     private float        _recordStartTime;
+#endif
 
     // handedness 안정화
     private bool _lastIsHand0Left      = true;
@@ -475,8 +481,10 @@ namespace Demo.GestureDetection
       // 필터 모드가 Inspector에서 바뀌면 즉시 재생성
       if (_filterMode != _activeFilterMode) RebuildFilters();
 
+#if GESTURE_METRICS
       // 기록 체크박스 on/off 엣지 처리 (on→버퍼 시작, off→CSV 저장)
       HandleRecordingEdge();
+#endif
 
       // lock으로 스냅샷을 안전하게 읽어옴 (메인 스레드에서만 사용)
       LandmarkSnapshot snap;
@@ -659,9 +667,11 @@ namespace Demo.GestureDetection
       Vector3 filteredWrist = handFilter.Update(rawWrist, Time.deltaTime, maxJump);
       handTarget.position = Vector3.Lerp(handTarget.position, filteredWrist, smoothT);
 
+#if GESTURE_METRICS
       // 평가용: 선택한 손의 raw(필터 입력) vs filtered(필터 출력) 기록
       if (_recordMetrics && isLeft == (_recordJoint == RecordJoint.LeftHand))
         RecordRow(rawWrist, filteredWrist);
+#endif
 
       if (elbowHint != null)
       {
@@ -897,6 +907,7 @@ namespace Demo.GestureDetection
       Debug.Log($"[GolemLandmarkAnimator] Filter mode = {_filterMode}");
     }
 
+#if GESTURE_METRICS
     // ─────────────────────────────────────────────────────────────────────────
     // 메트릭 CSV 기록: _recordMetrics 체크 on→기록 시작, off→파일 저장
     // 컬럼: time_s, dt_s, fps, filter_mode, raw_xyz, filt_xyz
@@ -958,6 +969,7 @@ namespace Demo.GestureDetection
       if (_wasRecording) WriteCsv();
       _wasRecording = false;
     }
+#endif
 
     private bool IsValidData(PoseLandmarkerResult poseResult, HandLandmarkerResult handResult)
     {

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureDetector.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureDetector.cs
@@ -37,6 +37,9 @@ namespace Demo.GestureDetection
     // LIVE_STREAM 모드용 최신 결과
     private HandLandmarkerResult _latestHandResult;
     private PoseLandmarkerResult _latestPoseResult;
+    // 이벤트 전달용 스냅샷: 콜백 스레드의 CloneTo와 경쟁하지 않도록 락 안에서 복사해 사용
+    private HandLandmarkerResult _handResultSnapshot;
+    private PoseLandmarkerResult _poseResultSnapshot;
     private readonly object _resultLock = new object();
     private bool _isHandResultDirty = false;
     private bool _isPoseResultDirty = false;
@@ -151,6 +154,8 @@ namespace Demo.GestureDetection
       {
         _latestHandResult = HandLandmarkerResult.Alloc(handOptions.numHands);
         _latestPoseResult = PoseLandmarkerResult.Alloc(poseOptions.numPoses, poseOptions.outputSegmentationMasks);
+        _handResultSnapshot = HandLandmarkerResult.Alloc(handOptions.numHands);
+        _poseResultSnapshot = PoseLandmarkerResult.Alloc(poseOptions.numPoses, poseOptions.outputSegmentationMasks);
       }
 
       Debug.Log("[GestureDetector] Entering main detection loop");
@@ -295,13 +300,18 @@ namespace Demo.GestureDetection
         {
           _isHandResultDirty = false;
           _isPoseResultDirty = false;
+
+          // 락 안에서 thread-private 스냅샷으로 복사 → 콜백 스레드의 CloneTo와 경쟁 제거
+          _latestHandResult.CloneTo(ref _handResultSnapshot);
+          _latestPoseResult.CloneTo(ref _poseResultSnapshot);
           shouldUpdate = true;
         }
       }
 
       if (shouldUpdate)
       {
-        OnLandmarksUpdated?.Invoke(_latestHandResult, _latestPoseResult);
+        // 스냅샷은 이 스레드(Run 코루틴)에서만 쓰고 Invoke는 동기 호출이라 안전
+        OnLandmarksUpdated?.Invoke(_handResultSnapshot, _poseResultSnapshot);
       }
     }
 

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureRecognizer.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureRecognizer.cs
@@ -104,9 +104,11 @@ namespace Demo.GestureDetection
         {
           // confidence 계산: 프레임 카운트 기반
           float confidence = Mathf.Min(1f, _gestureFrameCount[_currentGestureType] / (float)_holdFrames);
-          
-          Debug.Log($"[GestureRecognizer] {_currentGestureType} detected! Count={_gestureFrameCount[_currentGestureType]}, Confidence={confidence:F2}");
-          
+
+          // holdFrames 도달 첫 프레임에만 로그 (매 프레임 출력 방지)
+          if (_gestureFrameCount[_currentGestureType] == _holdFrames)
+            Debug.Log($"[GestureRecognizer] {_currentGestureType} detected! Count={_gestureFrameCount[_currentGestureType]}, Confidence={confidence:F2}");
+
           return new GestureResult(_currentGestureType, confidence, true, rawResult.Direction);
         }
       }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureRecognizer.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/GestureRecognizer.cs
@@ -116,15 +116,19 @@ namespace Demo.GestureDetection
       {
         // 실패: 유예 카운터 증가
         _gestureLostCount[_currentGestureType]++;
-        
+
         // 유예 프레임 초과 시 성공 카운터 리셋
         if (_gestureLostCount[_currentGestureType] > _maxLostFrames)
         {
           _gestureFrameCount[_currentGestureType] = 0;
           // Debug.Log($"[GestureRecognizer] {_currentGestureType} lost for {_maxLostFrames} frames, resetting counter");
         }
+
+        // 어떤 조건이 틀렸는지(FailReason)를 보존해서 반환 → 실패 피드백 집계용
+        return GestureResult.Fail(_currentGestureType, rawResult.FailReason);
       }
 
+      // 검출됐으나 holdFrames 누적 중(거의 성공 상태) → 실패 이유 없음
       return GestureResult.None;
     }
 

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/LiftGestureStrategy.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/LiftGestureStrategy.cs
@@ -88,9 +88,9 @@ namespace Demo.GestureDetection
 
       // Debug.Log($"[LiftUp] 손목: L({leftWrist.y:F3}) R({rightWrist.y:F3}) | 상승={isRisingMotion}, 기억={_risingFramesRemaining}, 최종={detected}");
 
-      return detected 
+      return detected
           ? new GestureResult(GestureType.Lift, 1.0f, true, Vector3.up)
-          : GestureResult.None;
+          : GestureResult.Fail(GestureType.Lift, GestureFailReason.NotRising);
     }
 
     /// <summary>

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/WindGestureStrategy.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Core/WindGestureStrategy.cs
@@ -91,10 +91,18 @@ namespace Demo.GestureDetection
       
       // 최종 조건
       bool success = bothHandsForward && angleIsOpposite_2D && wristsClose && bothHandsFingerExtended;
-      
-      return success 
-          ? new GestureResult(GestureType.Wind, 1.0f, true, Vector3.forward)
-          : GestureResult.None;
+
+      if (success)
+        return new GestureResult(GestureType.Wind, 1.0f, true, Vector3.forward);
+
+      // 실패한 조건들을 플래그로 모아서 반환 (가장 큰 실패 이유 집계용)
+      GestureFailReason reason = GestureFailReason.None;
+      if (!bothHandsForward)        reason |= GestureFailReason.PalmsNotForward;
+      if (!angleIsOpposite_2D)      reason |= GestureFailReason.HandsNotOpposite;
+      if (!wristsClose)             reason |= GestureFailReason.WristsTooFar;
+      if (!bothHandsFingerExtended) reason |= GestureFailReason.FingersNotOpen;
+
+      return GestureResult.Fail(GestureType.Wind, reason);
     }
 
     /// <summary>

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Data/GestureData.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Data/GestureData.cs
@@ -13,6 +13,26 @@ namespace Demo.GestureDetection
   }
 
   /// <summary>
+  /// 제스처 인식 실패 이유 (가장 큰 실패 원인 피드백용)
+  /// [Flags]로 한 프레임에 여러 조건이 동시에 실패할 수 있음.
+  /// </summary>
+  [System.Flags]
+  public enum GestureFailReason
+  {
+    None             = 0,
+    // ── Wind 전용 ──
+    PalmsNotForward  = 1 << 0, // 손바닥이 카메라를 향하지 않음
+    HandsNotOpposite = 1 << 1, // 두 손이 마주보지 않음(각도)
+    WristsTooFar     = 1 << 2, // 두 손목이 너무 떨어짐
+    FingersNotOpen   = 1 << 3, // 손가락이 덜 펴짐
+    // ── Lift 전용 ──
+    NotRising        = 1 << 4, // 팔을 위로 들어올리지 않음
+    // ── 공통(Presenter가 채움) ──
+    PoseMissing      = 1 << 5, // 몸(상체)이 화면에 안 보임
+    HandMissing      = 1 << 6, // 손이 잠깐씩 사라짐
+  }
+
+  /// <summary>
   /// 제스처 인식 결과 데이터
   /// </summary>
   public struct GestureResult
@@ -21,15 +41,21 @@ namespace Demo.GestureDetection
     public float Confidence;
     public bool IsDetected;
     public Vector3 Direction; // 제스처 방향 (필요시 사용)
+    public GestureFailReason FailReason; // 미검출 시 어떤 조건이 틀렸는지 (성공 시 None)
 
-    public GestureResult(GestureType type, float confidence, bool isDetected, Vector3 direction = default)
+    public GestureResult(GestureType type, float confidence, bool isDetected, Vector3 direction = default,
+                         GestureFailReason failReason = GestureFailReason.None)
     {
       Type = type;
       Confidence = confidence;
       IsDetected = isDetected;
       Direction = direction;
+      FailReason = failReason;
     }
 
     public static GestureResult None => new GestureResult(GestureType.None, 0f, false);
+
+    public static GestureResult Fail(GestureType type, GestureFailReason reason)
+      => new GestureResult(type, 0f, false, default, reason);
   }
 }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Scene/GestureSceneController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Scene/GestureSceneController.cs
@@ -1,3 +1,4 @@
+using TMPro;
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.UI;
@@ -12,6 +13,7 @@ namespace Demo.GestureDetection
     Entry,    // 진입 (초기화)
     Tutorial, // 튜토리얼 타임라인
     Playing,  // 플레이 중 (제스처 인식)
+    Paused,   // 실패 타임아웃 팝업 표시 중 (인식 일시정지)
     Success,  // 성공 (연출 준비)
     Exit      // 종료
   }
@@ -62,6 +64,36 @@ namespace Demo.GestureDetection
     [Tooltip("진행 바가 나타나기 시작하는 홀드 시간 (초)")]
     [SerializeField] private float _progressShowThreshold = 2f;
 
+    // ========== 실패 시 건너뛰기 ==========
+    [Header("Fail Skip - Timeout")]
+    [Tooltip("A: 손이 이 시간(초) 이상 안 보이면 위치 재조정 팝업")]
+    [SerializeField] private float _noHandTimeout = 5f;
+    [Tooltip("B: 양손은 보이지만 이 시간(초) 동안 한 번도 유지 성공 못하면 넘어가기 팝업")]
+    [SerializeField] private float _holdFailTimeout = 15f;
+
+    [Header("Fail Skip - UI")]
+    [Tooltip("설정 패널 Presenter. 비우면 자동 탐색. 설정창이 열려 있는 동안 타임아웃을 중단한다.")]
+    [SerializeField] private SettingsPresenter _settingsPresenter;
+    [Tooltip("반투명 실패 안내 오버레이 (기본 비활성)")]
+    [SerializeField] private GameObject _failOverlay;
+    [Tooltip("실패 이유 텍스트")]
+    [SerializeField] private TMP_Text _failReasonText;
+    [Tooltip("다시해보기 버튼 (인식 재개)")]
+    [SerializeField] private Button _retryButton;
+    [Tooltip("넘어가기 버튼 (성공 처리) — B(유지 실패)에서만 표시")]
+    [SerializeField] private Button _failSkipButton;
+
+    [Header("Fail Skip - Messages")]
+    [TextArea] [SerializeField] private string _msgNoHands         = "양손이 카메라 화면 안에 잘 보이도록 위치를 조정해 주세요.";
+    [TextArea] [SerializeField] private string _msgPoseMissing     = "몸 전체가 보이도록 카메라에서 조금 물러나 주세요.";
+    [TextArea] [SerializeField] private string _msgHandMissing     = "손이 화면 밖으로 자꾸 벗어나고 있어요. 손을 화면 안에 유지해 주세요.";
+    [TextArea] [SerializeField] private string _msgPalmsNotForward = "손바닥이 카메라를 향하도록 펴 주세요.";
+    [TextArea] [SerializeField] private string _msgHandsNotOpposite= "두 손을 마주보게 모아 주세요.";
+    [TextArea] [SerializeField] private string _msgWristsTooFar    = "두 손을 더 가까이 모아 주세요.";
+    [TextArea] [SerializeField] private string _msgFingersNotOpen  = "손가락을 쫙 펴 주세요.";
+    [TextArea] [SerializeField] private string _msgNotRising       = "두 팔을 위로 쭉 들어올려 주세요.";
+    [TextArea] [SerializeField] private string _msgGeneric         = "안내된 자세를 천천히 따라 해 보세요.";
+
     // Quest 연동 (읽기용)
     [Header("Quest - Objective IDs")]
     [SerializeField] private string _objectiveID_NoFly = "MQ-02-OBJ-02";
@@ -104,11 +136,34 @@ namespace Demo.GestureDetection
     private void Start()
     {
       SetupButtons();
+      HideFailOverlay();
+
+      // 설정창 가시성으로 타임아웃을 게이트 (열림 방식/씬 단독 실행과 무관하게 동작)
+      if (_settingsPresenter == null)
+        _settingsPresenter = FindFirstObjectByType<SettingsPresenter>(FindObjectsInactive.Include);
+
       EnterEntryState();
+    }
+
+    /// <summary>설정창 등으로 인식 타임아웃을 멈춰야 하는 상태인가</summary>
+    private bool IsRecognitionBlocked()
+    {
+      if (_settingsPresenter != null && _settingsPresenter.IsVisible)
+        return true;
+      if (GameStateManager.Instance != null && !GameStateManager.Instance.IsInState(GameState.Gameplay))
+        return true;
+      return false;
     }
     
     private void Update()
     {
+      // 설정창 등이 떠 있는 동안엔 타임아웃 타이머만 중단
+      // (Detector는 계속 동작 → 웹캠 미리보기 유지. 오버레이가 설정창 뒤에 뜨는 문제 방지)
+      if (_state == GestureSceneState.Playing && _gesturePlayPresenter != null)
+      {
+        _gesturePlayPresenter.SetTimersSuspended(IsRecognitionBlocked());
+      }
+
       // DEBUG: ESC 키로 강제 종료
       if (_debugOverride && Input.GetKeyDown(KeyCode.Escape) && _state != GestureSceneState.Exit)
       {
@@ -137,6 +192,12 @@ namespace Demo.GestureDetection
 
       if (_rewatchButton != null)
         _rewatchButton.onClick.AddListener(RewatchTutorial);
+
+      if (_retryButton != null)
+        _retryButton.onClick.AddListener(OnRetryClicked);
+
+      if (_failSkipButton != null)
+        _failSkipButton.onClick.AddListener(OnFailSkipClicked);
     }
 
     private void CleanupButtons()
@@ -146,6 +207,12 @@ namespace Demo.GestureDetection
 
       if (_rewatchButton != null)
         _rewatchButton.onClick.RemoveListener(RewatchTutorial);
+
+      if (_retryButton != null)
+        _retryButton.onClick.RemoveListener(OnRetryClicked);
+
+      if (_failSkipButton != null)
+        _failSkipButton.onClick.RemoveListener(OnFailSkipClicked);
     }
 
     // ========== 상태 전환 메서드 ==========
@@ -291,13 +358,94 @@ namespace Demo.GestureDetection
         thresholds: _sceneConfig?.thresholds,
         onSuccess: OnGestureSuccess,
         requiredHoldDuration:  _requiredHoldDuration,
-        progressShowThreshold: _progressShowThreshold
+        progressShowThreshold: _progressShowThreshold,
+        onTimeout: OnRecognitionTimeout,
+        noHandTimeout: _noHandTimeout,
+        holdFailTimeout: _holdFailTimeout
       );
       
       // 3. 플레이 시작
       _gesturePlayPresenter.StartPlay();
     }
     
+    // ========== 실패 시 건너뛰기 ==========
+
+    /// <summary>
+    /// 인식 타임아웃 콜백 (Presenter → Controller)
+    /// A(NoHands): 위치 재조정 안내 / B(HoldFail): 가장 큰 실패 이유 + 넘어가기
+    /// </summary>
+    private void OnRecognitionTimeout(UI.GestureTimeoutInfo info)
+    {
+      if (_state != GestureSceneState.Playing) return;
+
+      // 이중 안전장치: 설정창 등이 떠 있으면 오버레이를 띄우지 않음
+      // (복귀 시 Presenter.SetTimersSuspended(false)가 타이머를 리셋하므로 재무장됨)
+      if (IsRecognitionBlocked())
+        return;
+
+      // 모델 재로딩 없이 코루틴만 일시정지 (Stop 아님)
+      _gestureDetector?.Pause();
+      _gesturePlayPresenter?.PausePlay();
+
+      bool isNoHands = info.Type == UI.GestureTimeoutType.NoHands;
+      string message = isNoHands ? _msgNoHands : ReasonToText(info.Reason);
+
+      // A는 다시해보기만, B는 넘어가기까지 표시
+      ShowFailOverlay(message, showSkip: !isNoHands);
+      ChangeState(GestureSceneState.Paused);
+    }
+
+    /// <summary>다시해보기: 일시정지 해제 후 Playing 재개 (타이머 리셋)</summary>
+    private void OnRetryClicked()
+    {
+      if (_state != GestureSceneState.Paused) return;
+
+      HideFailOverlay();
+      _gestureDetector?.Resume();
+      _gesturePlayPresenter?.ResumePlay();
+      ChangeState(GestureSceneState.Playing);
+      Debug.Log("[GestureSceneController] Retry → recognition resumed");
+    }
+
+    /// <summary>넘어가기: 성공 처리로 전환 (Quest 완료 + 성공 연출)</summary>
+    private void OnFailSkipClicked()
+    {
+      if (_state != GestureSceneState.Paused) return;
+
+      HideFailOverlay();
+      Debug.Log("[GestureSceneController] Skip → forcing success");
+      // OnGestureSuccess가 Presenter.Cleanup()(=Detector.Stop)을 호출하므로 별도 정지 불필요
+      OnGestureSuccess(_targetGesture);
+    }
+
+    private void ShowFailOverlay(string message, bool showSkip)
+    {
+      if (_failReasonText != null) _failReasonText.text = message;
+      if (_failSkipButton != null) _failSkipButton.gameObject.SetActive(showSkip);
+      if (_failOverlay != null) _failOverlay.SetActive(true);
+    }
+
+    private void HideFailOverlay()
+    {
+      if (_failOverlay != null) _failOverlay.SetActive(false);
+    }
+
+    /// <summary>실패 이유 플래그 → 안내 문구 매핑</summary>
+    private string ReasonToText(GestureFailReason reason)
+    {
+      switch (reason)
+      {
+        case GestureFailReason.PoseMissing:      return _msgPoseMissing;
+        case GestureFailReason.HandMissing:      return _msgHandMissing;
+        case GestureFailReason.PalmsNotForward:  return _msgPalmsNotForward;
+        case GestureFailReason.HandsNotOpposite: return _msgHandsNotOpposite;
+        case GestureFailReason.WristsTooFar:     return _msgWristsTooFar;
+        case GestureFailReason.FingersNotOpen:   return _msgFingersNotOpen;
+        case GestureFailReason.NotRising:        return _msgNotRising;
+        default:                                 return _msgGeneric;
+      }
+    }
+
     /// <summary>
     /// 제스처 성공 콜백
     /// </summary>

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Presenters/GesturePlayPresenter.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Presenters/GesturePlayPresenter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using Mediapipe.Tasks.Vision.HandLandmarker;
 using Mediapipe.Tasks.Vision.PoseLandmarker;
@@ -5,11 +6,36 @@ using Mediapipe.Tasks.Vision.PoseLandmarker;
 namespace Demo.GestureDetection.UI
 {
   /// <summary>
+  /// 제스처 인식 타임아웃 종류
+  /// </summary>
+  public enum GestureTimeoutType
+  {
+    NoHands,   // A: 손이 일정 시간 동안 아예 안 보임 (위치 재조정 유도)
+    HoldFail   // B: 손은 보이지만 일정 시간 동안 유지 성공을 못함 (넘어가기 유도)
+  }
+
+  /// <summary>
+  /// 타임아웃 발생 정보 (Presenter → Controller)
+  /// </summary>
+  public struct GestureTimeoutInfo
+  {
+    public GestureTimeoutType Type;
+    public GestureFailReason Reason; // HoldFail일 때 "가장 큰 실패 이유"
+
+    public GestureTimeoutInfo(GestureTimeoutType type, GestureFailReason reason)
+    {
+      Type = type;
+      Reason = reason;
+    }
+  }
+
+  /// <summary>
   /// 제스처 플레이 로직 처리 (Presenter)
   /// - GestureDetector 이벤트 구독
   /// - GestureRecognizer 호출
   /// - View 업데이트 (View 내부 구조는 모름)
-  /// - 제스처 3초 유지 시 성공 콜백
+  /// - 제스처 일정 시간 유지 시 성공 콜백
+  /// - 인식 실패가 길어지면 타임아웃 콜백(A: 손 미검출 / B: 유지 실패)
   /// </summary>
   public class GesturePlayPresenter
   {
@@ -31,7 +57,31 @@ namespace Demo.GestureDetection.UI
     
     // 성공 콜백
     private System.Action<GestureType> _onGestureSuccess;
-    
+
+    // ── 실패 타임아웃 ──
+    private System.Action<GestureTimeoutInfo> _onTimeout;
+    private float _noHandTimeout = 5f;    // A: 손 미검출 허용 시간
+    private float _holdFailTimeout = 15f;  // B: 유지 실패 허용 시간
+    private bool _sessionStarted = false;  // 양손이 처음 잡힌 이후 true
+    private float _sessionStartTime = -1f;
+    private float _lastHandSeenTime = -1f;
+    private bool _timedOut = false;
+    private bool _isPaused = false;
+    private bool _timersSuspended = false; // 설정창 등 비-게임플레이 상태에서 타이머만 중단
+
+    // 실패 이유별 누적 카운트 (고정 키 7개 — 컬렉션이 커지지 않음)
+    private static readonly GestureFailReason[] _allReasons =
+    {
+      GestureFailReason.PalmsNotForward,
+      GestureFailReason.HandsNotOpposite,
+      GestureFailReason.WristsTooFar,
+      GestureFailReason.FingersNotOpen,
+      GestureFailReason.NotRising,
+      GestureFailReason.PoseMissing,
+      GestureFailReason.HandMissing,
+    };
+    private readonly Dictionary<GestureFailReason, int> _failCounts = new Dictionary<GestureFailReason, int>();
+
     /// <summary>
     /// 초기화
     /// </summary>
@@ -42,7 +92,10 @@ namespace Demo.GestureDetection.UI
       GestureThresholdData thresholds,
       System.Action<GestureType> onSuccess,
       float requiredHoldDuration = 3f,
-      float progressShowThreshold = 2f)
+      float progressShowThreshold = 2f,
+      System.Action<GestureTimeoutInfo> onTimeout = null,
+      float noHandTimeout = 5f,
+      float holdFailTimeout = 15f)
     {
       _view = view;
       _gestureDetector = detector;
@@ -50,11 +103,15 @@ namespace Demo.GestureDetection.UI
       _onGestureSuccess = onSuccess;
       _requiredHoldDuration = requiredHoldDuration;
       _progressShowThreshold = progressShowThreshold;
+      _onTimeout = onTimeout;
+      _noHandTimeout = noHandTimeout;
+      _holdFailTimeout = holdFailTimeout;
 
       // 상태 초기화
       _holdStartTime = -1f;
       _successTriggered = false;
-      
+      ResetTimeoutState();
+
       // GestureRecognizer 생성 및 설정
       _gestureRecognizer = new GestureRecognizer(thresholds ?? GestureThresholdData.Default());
       _gestureRecognizer.SetActiveGesture(targetGesture);
@@ -85,44 +142,65 @@ namespace Demo.GestureDetection.UI
     /// </summary>
     private void OnLandmarksUpdated(HandLandmarkerResult handResult, PoseLandmarkerResult poseResult)
     {
-      // 1. 데이터 유효성 검사
-      bool hasHandData = IsValidHandData(handResult);
-      bool hasPoseData = poseResult.poseLandmarks != null && poseResult.poseLandmarks.Count > 0;
-      
-      if (!hasHandData || !hasPoseData)
+      // 일시정지 중(타임아웃 팝업 표시 중)에는 들어오는 잔여 이벤트 무시
+      if (_isPaused)
       {
-        // 데이터 부족 시 홀드 타이머 리셋
-        ResetHoldTimer();
-
-        // 뷰에 전달
-        _view?.UpdateDisplay(new DisplayData
-        {
-          HasValidData = false
-        });
-        
         DisposeAllMasks(poseResult);
         return;
       }
-      
-      // 2. 제스처 인식
+
+      // 1. 데이터 유효성 검사
+      bool hasHandData = IsValidHandData(handResult);
+      bool hasPoseData = poseResult.poseLandmarks != null && poseResult.poseLandmarks.Count > 0;
+
+      // 2. 세션 시작 / 손 추적 갱신 (양손이 보이는 순간부터 타이머 가동)
+      float now = Time.time;
+      if (hasHandData)
+      {
+        _lastHandSeenTime = now;
+        if (!_sessionStarted)
+        {
+          _sessionStarted = true;
+          _sessionStartTime = now;
+          UnityEngine.Debug.Log("[GesturePlayPresenter] Session started (both hands detected)");
+        }
+      }
+
+      // 3. 데이터 부족 분기
+      if (!hasHandData || !hasPoseData)
+      {
+        // 실패 이유 집계 (B 타임아웃 텍스트용)
+        AccumulateFailReason(hasHandData, hasPoseData, GestureFailReason.None);
+
+        // 데이터 부족 시 홀드 타이머 리셋
+        ResetHoldTimer();
+
+        _view?.UpdateDisplay(new DisplayData { HasValidData = false });
+
+        CheckTimeouts(now);
+        DisposeAllMasks(poseResult);
+        return;
+      }
+
+      // 4. 제스처 인식
       var gestureResult = _gestureRecognizer.RecognizeGesture(handResult, poseResult);
-      
-      // 3. 타겟 제스처 3초 유지 판정
+
+      // 5. 타겟 제스처 유지 판정
       bool isTargetDetected = gestureResult.Type == _targetGesture && gestureResult.IsDetected;
-      
+
       if (isTargetDetected && !_successTriggered)
       {
         // 홀드 시작 또는 유지
         if (_holdStartTime < 0f)
         {
-          _holdStartTime = Time.time;
+          _holdStartTime = now;
           UnityEngine.Debug.Log($"[GesturePlayPresenter] Hold started: {gestureResult.Type}");
         }
         else
         {
-          float holdDuration = Time.time - _holdStartTime;
-          
-          // 3초 도달 시 성공 콜백
+          float holdDuration = now - _holdStartTime;
+
+          // 요구 시간 도달 시 성공 콜백
           if (holdDuration >= _requiredHoldDuration)
           {
             _successTriggered = true;
@@ -133,11 +211,12 @@ namespace Demo.GestureDetection.UI
       }
       else if (!isTargetDetected)
       {
-        // 제스처 끊김 → 홀드 타이머 리셋
+        // 제스처 끊김 → 홀드 타이머 리셋 + 실패 이유 집계
         ResetHoldTimer();
+        AccumulateFailReason(hasHandData, hasPoseData, gestureResult.FailReason);
       }
-      
-      // 4. View 업데이트 (단일 진입점)
+
+      // 6. View 업데이트 (단일 진입점)
       _view?.UpdateDisplay(new DisplayData
       {
         PoseData = poseResult,
@@ -147,9 +226,96 @@ namespace Demo.GestureDetection.UI
         HoldProgress = CalculateHoldProgress(),
         ShowProgress = ShouldShowProgress()
       });
-      
-      // 5. 메모리 정리 (Pose segmentation masks)
+
+      // 7. 타임아웃 체크
+      CheckTimeouts(now);
+
+      // 8. 메모리 정리 (Pose segmentation masks)
       DisposeAllMasks(poseResult);
+    }
+
+    /// <summary>
+    /// A/B 타임아웃 검사. 세션 시작 후, 미성공·미타임아웃 상태에서만 동작.
+    /// </summary>
+    private void CheckTimeouts(float now)
+    {
+      if (_timersSuspended || !_sessionStarted || _timedOut || _successTriggered) return;
+
+      // A: 손 미검출 — 손이 마지막으로 보인 뒤 _noHandTimeout 경과
+      if (_lastHandSeenTime >= 0f && (now - _lastHandSeenTime) >= _noHandTimeout)
+      {
+        _timedOut = true;
+        UnityEngine.Debug.Log("[GesturePlayPresenter] Timeout A (NoHands)");
+        _onTimeout?.Invoke(new GestureTimeoutInfo(GestureTimeoutType.NoHands, GestureFailReason.None));
+        return;
+      }
+
+      // B: 유지 실패 — 세션 시작 후 _holdFailTimeout 동안 한 번도 성공 못함
+      if ((now - _sessionStartTime) >= _holdFailTimeout)
+      {
+        _timedOut = true;
+        var reason = GetDominantFailReason();
+        UnityEngine.Debug.Log($"[GesturePlayPresenter] Timeout B (HoldFail), reason={reason}");
+        _onTimeout?.Invoke(new GestureTimeoutInfo(GestureTimeoutType.HoldFail, reason));
+      }
+    }
+
+    /// <summary>
+    /// 실패 이유 누적 (고정 키 카운터 — 가장 큰 실패 이유 산출용)
+    /// </summary>
+    private void AccumulateFailReason(bool hasHandData, bool hasPoseData, GestureFailReason strategyReason)
+    {
+      if (_timersSuspended || !_sessionStarted || _successTriggered) return;
+
+      if (!hasPoseData)
+      {
+        _failCounts[GestureFailReason.PoseMissing]++;
+      }
+      else if (!hasHandData)
+      {
+        // 손이 잠깐씩 사라짐 (5초 이상 지속되면 A로 별도 처리)
+        _failCounts[GestureFailReason.HandMissing]++;
+      }
+      else
+      {
+        // 손/몸 다 보이는데 미검출 → 전략이 알려준 조건들 집계
+        foreach (var r in _allReasons)
+        {
+          if ((strategyReason & r) != 0)
+            _failCounts[r]++;
+        }
+      }
+    }
+
+    /// <summary>
+    /// 누적된 실패 이유 중 최다 항목 반환 (없으면 None)
+    /// </summary>
+    private GestureFailReason GetDominantFailReason()
+    {
+      GestureFailReason best = GestureFailReason.None;
+      int bestCount = 0;
+      foreach (var r in _allReasons)
+      {
+        if (_failCounts[r] > bestCount)
+        {
+          bestCount = _failCounts[r];
+          best = r;
+        }
+      }
+      return best;
+    }
+
+    /// <summary>
+    /// 세션/타이머/실패 카운트 초기화 (키도 함께 보장)
+    /// </summary>
+    private void ResetTimeoutState()
+    {
+      _sessionStarted = false;
+      _sessionStartTime = -1f;
+      _lastHandSeenTime = -1f;
+      _timedOut = false;
+      foreach (var r in _allReasons)
+        _failCounts[r] = 0;
     }
 
     /// <summary>
@@ -234,6 +400,50 @@ namespace Demo.GestureDetection.UI
       UnityEngine.Debug.Log($"[GesturePlayPresenter] Target gesture changed to: {newGesture}");
     }
     
+    /// <summary>
+    /// 인식 일시정지 (타임아웃 팝업 표시 중).
+    /// Detector 자체의 Pause()는 Controller가 호출 — 여기선 잔여 이벤트만 무시.
+    /// </summary>
+    public void PausePlay()
+    {
+      _isPaused = true;
+    }
+
+    /// <summary>
+    /// 타임아웃 타이머만 일시중단/재개 (설정창 등 비-게임플레이 상태용).
+    /// Detector는 계속 동작(웹캠 미리보기가 라이브 텍스처를 빌려쓰므로).
+    /// 재개 시 중단 동안 흐른 시간을 제외하기 위해 세션/타이머를 리셋한다.
+    /// </summary>
+    public void SetTimersSuspended(bool suspended)
+    {
+      if (_timersSuspended == suspended) return;
+      _timersSuspended = suspended;
+
+      if (!suspended)
+      {
+        // 재개: 중단 동안의 경과를 무효화하고 새 세션으로 재시작
+        _holdStartTime = -1f;
+        ResetTimeoutState();
+        UnityEngine.Debug.Log("[GesturePlayPresenter] Timers resumed (state back to Gameplay)");
+      }
+      else
+      {
+        UnityEngine.Debug.Log("[GesturePlayPresenter] Timers suspended (non-gameplay state)");
+      }
+    }
+
+    /// <summary>
+    /// 인식 재개 (다시해보기). 세션/타이머/실패 카운트를 모두 리셋하여
+    /// 양손이 다시 잡히는 순간부터 새 세션으로 시작한다.
+    /// </summary>
+    public void ResumePlay()
+    {
+      _holdStartTime = -1f;
+      ResetTimeoutState();
+      _isPaused = false;
+      UnityEngine.Debug.Log("[GesturePlayPresenter] Resumed (timers/fail-counts reset)");
+    }
+
     /// <summary>
     /// 정리
     /// </summary>

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GesturePlayView.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GesturePlayView.cs
@@ -63,10 +63,12 @@ namespace Demo.GestureDetection.UI
     /// </summary>
     public void UpdateDisplay(DisplayData data)
     {
-      // 1. 데이터 유효성에 따른 Avatar 업데이트
+      // 1. 데이터 유효성 체크
       if (!data.HasValidData)
       {
-        ResetAvatar();
+        // ResetAvatar() 호출 안 함: 두 손이 가까워 한쪽이 잠깐 미검출될 때마다
+        // IK weight가 0으로 즉시 스냅되어 팔이 깜빡인다. GolemLandmarkAnimator의
+        // _dataTimeout(1초) + ReturnTargetsToRest()가 데이터 끊김을 부드럽게 처리한다.
         UpdateHoldProgressBar(0f, false);
         return;
       }

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GestureUIController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/UI/Views/GestureUIController.cs
@@ -62,20 +62,14 @@ namespace Demo.GestureDetection.UI
     /// </summary>
     public void UpdateGestureResult(GestureResult result)
     {
-      // 타겟 제스처만 반응
-      if (result.Type == _targetGesture && result.IsDetected)
-      {
-        _isActive = true;
+      bool wasActive = _isActive;
+
+      // Recognizer는 활성 전략 하나만 평가 → result.Type은 타겟 또는 None
+      _isActive = result.Type == _targetGesture && result.IsDetected;
+
+      // 비활성 → 활성 전환 시에만 로그 (매 프레임 출력 방지)
+      if (_isActive && !wasActive)
         Debug.Log($"[GestureUIController] {_targetGesture} detected - activating indicator");
-      }
-      else
-      {
-        _isActive = false;
-        if (result.Type != GestureType.None)
-        {
-          Debug.Log($"[GestureUIController] Detected {result.Type}, but target is {_targetGesture}");
-        }
-      }
     }
 
     /// <summary>

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Systems/Interactions/Scripts/ForestAfternoonController.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Systems/Interactions/Scripts/ForestAfternoonController.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.SceneManagement;
@@ -68,11 +69,30 @@ public class ForestAfternoonController : MonoBehaviour
         requestStartDialogueEvent?.Raise("DLG-012");
     }
 
-    // DLG-012 완료 → 씬 전환
+    // DLG-012 완료 → 타임라인 종료까지 대기 후 씬 전환
     private void OnDialogueCompleted()
     {
         if (!_waitingForDialogueComplete) return;
         _waitingForDialogueComplete = false;
+        StartCoroutine(LoadNextSceneAfterTimeline());
+    }
+
+    /// <summary>
+    /// Yarn 대화가 끝나도 컷씬 Timeline이 끝까지 재생될 때까지 대기한 뒤 씬을 전환한다.
+    /// extrapolationMode = Hold라 타임라인이 끝나도 stopped 이벤트가 발생하지 않으므로
+    /// time이 duration에 도달했는지로 종료를 판정한다.
+    /// </summary>
+    private IEnumerator LoadNextSceneAfterTimeline()
+    {
+        if (cutsceneDirector != null)
+        {
+            while (cutsceneDirector.state == PlayState.Playing &&
+                   cutsceneDirector.time < cutsceneDirector.duration)
+            {
+                yield return null;
+            }
+        }
+
         SceneManager.LoadScene(nextScene);
     }
 


### PR DESCRIPTION
## Summary

제스처 인식이 일정 시간 동안 실패하면 안내 오버레이를 띄워 **다시해보기** 또는 **넘어가기**를 선택할 수 있는 기능 추가.

## Features

**타임아웃 A — 손 미검출 (기본 7초)**
양손이 카메라에 보이지 않으면 위치 재조정 안내 팝업 표시.
다시해보기로 인식 재개.

**타임아웃 B — 유지 실패 (기본 25초)**
양손은 보이지만 제스처 유지에 계속 실패하면 팝업 표시.
실패 이유(손바닥 방향, 손 간격, 손가락 펴기 등)를 집계해 가장 큰 원인을 안내 문구로 표시.
다시해보기 또는 넘어가기(성공 처리) 선택 가능.

**타이머 게이팅**
설정창이 열려 있는 동안은 타임아웃 타이머가 중단되고, 닫히면 새 세션으로 재시작.

## Test Plan

- [X] 손을 5초 이상 숨기면 A 오버레이가 뜨는지
- [X] 양손이 보이는 상태로 25초 버티면 B 오버레이가 뜨는지
- [X] B 오버레이의 안내 문구가 실제 실패 원인과 일치하는지
- [X] 다시해보기 후 타이머가 리셋되는지
- [X] 넘어가기 시 성공 처리로 진행되는지
- [X] 설정창 열린 동안 타이머가 멈추는지