### PR TITLE
feat: set OneEuro filter defaults to minCutoff=2, beta=2

### DIFF
--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scenes/Gesture Detection Wind.unity
@@ -8731,6 +8731,7 @@ MonoBehaviour:
   _progressShowThreshold: 2
   _noHandTimeout: 7
   _holdFailTimeout: 25
+  _settingsPresenter: {fileID: 0}
   _failOverlay: {fileID: 1256679741}
   _failReasonText: {fileID: 1573427433}
   _retryButton: {fileID: 1465251208}
@@ -9770,11 +9771,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _beta
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _minCutoff
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3722908329779218347, guid: 03e78cf2e71498e4db7076fcde8690e4, type: 3}
       propertyPath: _positionDeadzone

--- a/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
+++ b/GoGoGolem/src/unity/GoGoGolem/Assets/Scripts/Runtime/Multimodal/Gesture/Animation/GolemLandmarkAnimator.cs
@@ -287,9 +287,9 @@ namespace Demo.GestureDetection
 
     [Header("Jitter Filter Settings (One Euro Filter)")]
     [Tooltip("정지 시 필터 강도. 낮을수록 떨림 더 제거 (권장: 0.5~3.0)")]
-    [SerializeField] private float _minCutoff = 1.0f;
+    [SerializeField] private float _minCutoff = 2.0f;
     [Tooltip("속도 민감도. 높을수록 빠른 동작에 더 즉각 반응 (권장: 0.01~0.3)")]
-    [SerializeField] private float _beta = 0.05f;
+    [SerializeField] private float _beta = 2.0f;
 
 #if GESTURE_METRICS
     [Header("Metrics Recording (CSV, 평가용 — GESTURE_METRICS define 시에만 컴파일)")]


### PR DESCRIPTION
Apply the finalized OneEuro parameters from the filter comparison analysis to both the GolemLandmarkAnimator defaults and the gesture scene prefab override.